### PR TITLE
Fix subscriber signup and deletion requests

### DIFF
--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 //	License type: BSD 3-Clause License
 //	License copy: https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/LICENSE

--- a/src/RESTAPI/RESTAPI_signup_handler.cpp
+++ b/src/RESTAPI/RESTAPI_signup_handler.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-02-20.
 //


### PR DESCRIPTION
  [#2] [OWPROV][SUBSCRIBER] Fix subscriber signup and deletion APIs
    
    Fix Type: Bugfix
    Root Cause:
    - POST /signup allowed creating subscribers with duplicate email or device.
    - DELETE /subscriber did not remove all related records or unlink subscriber from inventory and owgw tables.
    
    Solution:
    - Added checks in POST /signup to reject existing emails and devices.
    - Updated DELETE /subscriber to remove subscriber records from all related tables.
