### PR TITLE
Allow updation of signup table when a subscriber's gateway device is changed/deleted

### DIFF
--- a/src/RESTAPI/RESTAPI_signup_handler.cpp
+++ b/src/RESTAPI/RESTAPI_signup_handler.cpp
@@ -163,7 +163,6 @@ namespace OpenWifi {
 		auto SignupUUID = GetParameter("signupUUID");
 		auto Operation = GetParameter("operation");
 		auto UserId = GetParameter("userId");
-		auto macAddress = GetParameter("mac");
 
 		poco_information(Logger(), fmt::format("signup-progress: {} - {} ", SignupUUID, Operation));
 		if ((SignupUUID.empty() && UserId.empty()) || Operation.empty()) {
@@ -193,8 +192,15 @@ namespace OpenWifi {
 			SE.to_json(Answer);
 			return ReturnObject(Answer);
 		}
-
+		/*
+		 - For updateMac operation, the mac parameter must be present.
+		 - An empty value (mac="") is allowed and denotes deletion of macAddress from table.
+		*/
 		if (Operation == "updateMac") {
+			std::string macAddress;
+			if (!HasParameter("mac", macAddress)) {
+				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
+			}
 			poco_information(Logger(),fmt::format("Updating Signup device to [{}] for subscriber: [{}].", macAddress, SE.email));
 			SE.macAddress = macAddress;
 			SE.serialNumber = macAddress;


### PR DESCRIPTION
**Problem Fixed:-**

OWPROV did not allow updating the device macAddress of subscriber once a signup record was created.
This made it hard to change the device associated with a subscriber’s signup record when a gateway device was deleted or replaced.

This PR allows updating the device data for an existing signup record in OWPROV by extending the signup API.

**Current Behaviour:-**
- When a PUT request is called, the signup record is located using userId of subscriber as well.
- If operation=updateMac, the provided mac value is used to update both macAddress and serialNumber fields of the existing signup record.