### PR TITLE
Fix subscriber signup "serialnumber" column updation and prevent deletion of device from inventory after signup completed

### DIFF
--- a/src/RESTAPI/RESTAPI_signup_handler.cpp
+++ b/src/RESTAPI/RESTAPI_signup_handler.cpp
@@ -135,6 +135,7 @@ namespace OpenWifi {
 			se.info.id = SignupUUID;
 			se.info.created = se.info.modified = se.submitted = now;
 			se.completed = 0;
+			se.serialNumber = macAddress;
 			se.macAddress = macAddress;
 			se.error = 0;
 			se.userId = UI.id;
@@ -246,7 +247,7 @@ namespace OpenWifi {
 			poco_information(Logger(),
 							 fmt::format("Looking for signup for {}: Mac {}", EMail, macAddress));
 			if (StorageService()->SignupDB().GetRecords(0, 100, SEs,
-														" serialNumber='" + macAddress + "' ")) {
+														" macAddress='" + macAddress + "' ")) {
 				return ReturnObject("signups", SEs);
 			}
 			return NotFound();

--- a/src/Signup.cpp
+++ b/src/Signup.cpp
@@ -117,10 +117,6 @@ namespace OpenWifi {
 								Logger(),
 								fmt::format("Creating subscriber device for {}", SD.serialNumber));
 							StorageService()->SubscriberDeviceDB().CreateRecord(SD);
-							poco_information(Logger(), fmt::format("Removing old inventory for {}",
-																   SD.serialNumber));
-							StorageService()->InventoryDB().DeleteRecord("serialNumber",
-																		 SD.serialNumber);
 
 							SE.status = "signup completed";
 							SE.serialNumber = SerialNumber;


### PR DESCRIPTION
[#13]
**Problem Fixed:-**
- After a subscriber signups with correct email, macAddress and registrationId, **before verifying** the email address, the **signup table** in provisioning contains empty **serialNumber** column but populated **macAddress** column.
- The **Get signup** record api was also **fetching** record by using the **serialNumber column** data when a macAddress is provided due to which if serialnumber remained **empty**, no record for that device would be found.

This PR fixes the updation and fetching of signup record by macAddress value.

**Current Behaviour:-**
- When a subscriber signups, both the serialNumber and macAddres are updated.
- If a GET /signup request is called with mac as query parameter, the macAddress column data is used to find and fetch the record.


[#8]
**Problem Fixed:-**
- After **verifying email** and completing the signup of a subscriber, the **Inventory record** of that device would be **deleted** until the device is readded in inventory through **reconnect**(~60 seconds later).
- Due to this if some other api which needed inventory record of the device queried the databse, it would return **not-found** error.

This PR fixes the deletion of inventory record of successful signup device.

**Current Behaviour:-**
- After a subscriber verifies the email, the inventory record persists and doesn't get deleted. 
- This way any api needing the Inventory record of that device can use it instantly without any delay.