### PR TITLE
Fix subscriber device update API to return an error when configuration is not applied

### DIFF
--- a/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-04-06.
 //
@@ -118,7 +123,9 @@ namespace OpenWifi {
 			Existing.configuration = UpdateObj.configuration;
 		}
 		StorageService()->SubscriberDeviceDB().UpdateRecord("id", uuid, Existing);
-		ApplyConfiguration(Existing.serialNumber);
+		if (!ApplyConfiguration(Existing.serialNumber)) {
+			return BadRequest(RESTAPI::Errors::SubConfigNotRefreshed);
+		}
 		return ReturnUpdatedObject(DB_, Existing, *this);
 	}
 


### PR DESCRIPTION
[#15]
**Problem Fixed:-**
- Updating a subscriber device would return 200 OK even when the new configuration was not applied on the device.
- This PR fixes the API response so it does not report success when the configuration push fails.

**Current Behaviour:-**
- If applying the configuration fails, the subscriber device update API returns an error instead of 200 OK.

**Test Screenshots:-**

- Provisioning UI showing error when applying configuration fails:-
<img width="1365" height="648" alt="Screenshot from 2026-01-14 20-06-14" src="https://github.com/user-attachments/assets/5e228f15-3cae-4cef-bf0e-d506274dea1e" />

- Error logs:-
<img width="1354" height="122" alt="Screenshot from 2026-01-14 19-36-56" src="https://github.com/user-attachments/assets/9df415ba-84d3-4c1c-ba06-2bfd10d30bc4" />
