### PR TITLE
[PROV][API] Enable Switch configuration validation support

### DIFF
--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -566,7 +566,9 @@ namespace OpenWifi {
 						ProvObjects::DeviceConfiguration DC;
 						if (DC.from_json(ConfigurationDetails)) {
 							if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
-								if (!ValidateConfigBlock(ConfigurationValidator::ConfigurationType::AP,DC, Errors)) {
+								auto ValidationType =
+									ConfigurationValidator::GetType(NewObject.platform);
+								if (!ValidateConfigBlock(ValidationType, DC, Errors)) {
 									break;
 								}
 								ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, DC.info);

--- a/src/RESTObjects/RESTAPI_ProvObjects.cpp
+++ b/src/RESTObjects/RESTAPI_ProvObjects.cpp
@@ -621,8 +621,17 @@ namespace OpenWifi::ProvObjects {
 			field_from_json(Obj, "realMacAddress", realMacAddress);
 			field_from_json(Obj, "doNotAllowOverrides", doNotAllowOverrides);
             field_from_json(Obj, "imported", imported);
-            field_from_json(Obj, "connected", connected);
-            field_from_json(Obj, "platform", platform);
+			field_from_json(Obj, "connected", connected);
+			field_from_json(Obj, "platform", platform);
+			if (Obj->has("deviceGroup")) {
+				std::string deviceGroup;
+				field_from_json(Obj, "deviceGroup", deviceGroup);
+				if (!deviceGroup.empty()) {
+					// For validation flows, deviceGroup takes precedence over platform.
+					Poco::toUpperInPlace(deviceGroup);
+					platform = deviceGroup;
+				}
+			}
 			return true;
 		} catch (...) {
 		}


### PR DESCRIPTION
Issue No: https://github.com/routerarchitects/ra-wlan-cloud-owprov/issues/28

Fix Type: Enhancement

Root Cause:
- Backend configuration validation was primarily aligned with AP devices.
- Switch configurations were not validated using the appropriate schema.
- Device group context was not consistently considered during validation.

Solution:
- Introduced device group–aware validation in the provisioning API.
- Ensured Switch configurations are validated against the correct schema.
- Maintained compatibility with existing configurations by preserving default AP behavior when device group is not specified.