### PR TITLE
[#6][feat]: Implement Kafka based synchronization for venue, subscriber, and their associated devices with CGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,16 @@
+#[[
+   SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+   Copyright (c) 2025 Infernet Systems Pvt Ltd
+   Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ ]]
 cmake_minimum_required(VERSION 3.13)
 project(owprov VERSION 4.1.0)
 
 set(CMAKE_CXX_STANDARD 17)
-
+option(CGW_INTEGRATION "Enable CGW Integration" ON)
+if(CGW_INTEGRATION)
+    add_compile_definitions(CGW_INTEGRATION)
+endif()
 if(UNIX AND APPLE)
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
     set(MYSQL_ROOT_DIR /usr/local/opt/mysql-client)
@@ -150,6 +158,7 @@ add_executable(owprov
         src/storage/storage_signup.cpp src/storage/storage_signup.h
         src/storage/storage_variables.cpp src/storage/storage_variables.h
         src/storage/storage_overrides.cpp src/storage/storage_overrides.h
+        src/storage/storage_groupsmap.cpp src/storage/storage_groupsmap.h
 
         src/RESTAPI/RESTAPI_entity_handler.cpp src/RESTAPI/RESTAPI_entity_handler.h
         src/RESTAPI/RESTAPI_contact_handler.cpp src/RESTAPI/RESTAPI_contact_handler.h

--- a/src/InfraGroupEvents.h
+++ b/src/InfraGroupEvents.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#ifdef CGW_INTEGRATION
+
+#include <cstdint>
+
+#include "framework/KafkaManager.h"
+#include "framework/KafkaTopics.h"
+#include "framework/MicroServiceFuncs.h"
+#include "framework/OpenWifiTypes.h"
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+
+namespace OpenWifi {
+
+	inline void PrepareInfraGroupEventJson(Poco::JSON::Object &Payload,
+										   const std::string &EventType,
+										   std::uint64_t GroupId,
+										   const Types::StringVec &Infras = {}) {
+		Payload.set("type", EventType);
+		Payload.set("infra_group_id", std::to_string(GroupId));
+		Payload.set("uuid", MicroServiceCreateUUID());
+
+		if (!Infras.empty()) {
+			Poco::JSON::Array InfraList;
+			for (const auto &infra : Infras) {
+				InfraList.add(infra);
+			}
+			Payload.set("infra_group_infras", InfraList);
+		}
+	}
+
+	inline void PublishInfraGroupEvent(const std::string &EventType,
+									   std::uint64_t GroupId,
+									   const Types::StringVec &Infras = {}) {
+		Poco::JSON::Object Payload;
+		PrepareInfraGroupEventJson(Payload, EventType, GroupId, Infras);
+		KafkaManager()->PostMessage(KafkaTopics::CNC, std::to_string(GroupId), Payload,false);
+	}
+
+} // namespace OpenWifi
+
+#endif // CGW_INTEGRATION

--- a/src/InfraGroupEvents.h
+++ b/src/InfraGroupEvents.h
@@ -22,7 +22,7 @@ namespace OpenWifi {
 
 	inline void PrepareInfraGroupEventJson(Poco::JSON::Object &Payload,
 										   const std::string &EventType,
-										   std::uint64_t GroupId,
+										   std::uint32_t GroupId,
 										   const Types::StringVec &Infras = {}) {
 		Payload.set("type", EventType);
 		Payload.set("infra_group_id", std::to_string(GroupId));
@@ -38,7 +38,7 @@ namespace OpenWifi {
 	}
 
 	inline void PublishInfraGroupEvent(const std::string &EventType,
-									   std::uint64_t GroupId,
+									   std::uint32_t GroupId,
 									   const Types::StringVec &Infras = {}) {
 		Poco::JSON::Object Payload;
 		PrepareInfraGroupEventJson(Payload, EventType, GroupId, Infras);

--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -24,7 +24,9 @@
 #include "framework/utils.h"
 #include "sdks/SDK_gw.h"
 #include "sdks/SDK_sec.h"
-
+#ifdef CGW_INTEGRATION
+#include "InfraGroupEvents.h"
+#endif
 namespace OpenWifi {
 
 	void RESTAPI_inventory_handler::DoGet() {
@@ -187,6 +189,16 @@ namespace OpenWifi {
 						 "", Existing.info.id);
 		DB_.DeleteRecord("id", Existing.info.id);
 		SerialNumberCache()->DeleteSerialNumber(SerialNumber);
+#ifdef CGW_INTEGRATION
+						
+			uint64_t groupId = -1;
+			if (!StorageService()->GroupsMapDB().GetGroup(Existing.venue, groupId)) {
+				poco_error(Logger(), fmt::format("{}: No CGW group mapping for venue {}", SerialNumber, Existing.venue));
+			}
+			
+			PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{SerialNumber});
+			poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: SerialNumber ({})", Existing.venue,SerialNumber));
+#endif
 		return OK();
 	}
 
@@ -303,6 +315,16 @@ namespace OpenWifi {
 							 NewObject.entity, NewObject.info.id);
 			ManageMembership(StorageService()->VenueDB(), &ProvObjects::Venue::devices, "",
 							 NewObject.venue, NewObject.info.id);
+#ifdef CGW_INTEGRATION
+						
+			uint64_t groupId = -1;
+			if (!StorageService()->GroupsMapDB().GetGroup(NewObject.venue, groupId)) {
+				poco_error(Logger(), fmt::format("{}: No CGW group mapping for venue {}", SerialNumber, NewObject.venue));
+			}
+			
+			PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{SerialNumber});
+			poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: SerialNumber ({})", NewObject.venue,SerialNumber));
+#endif
 			ProvObjects::InventoryTag NewTag;
 			DB_.GetRecord("id", NewObject.info.id, NewTag);
 			Poco::JSON::Object Answer;

--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -191,13 +191,13 @@ namespace OpenWifi {
 		SerialNumberCache()->DeleteSerialNumber(SerialNumber);
 #ifdef CGW_INTEGRATION
 						
-			uint64_t groupId = -1;
+			std::uint32_t groupId = 0;
 			if (!StorageService()->GroupsMapDB().GetGroup(Existing.venue, groupId)) {
 				poco_error(Logger(), fmt::format("{}: No CGW group mapping for venue {}", SerialNumber, Existing.venue));
+			} else {
+				PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{SerialNumber});
+				poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: groupID ({}), SerialNumber ({})", Existing.venue, groupId, SerialNumber));
 			}
-			
-			PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{SerialNumber});
-			poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: SerialNumber ({})", Existing.venue,SerialNumber));
 #endif
 		return OK();
 	}
@@ -317,13 +317,13 @@ namespace OpenWifi {
 							 NewObject.venue, NewObject.info.id);
 #ifdef CGW_INTEGRATION
 						
-			uint64_t groupId = -1;
+			std::uint32_t groupId = 0;
 			if (!StorageService()->GroupsMapDB().GetGroup(NewObject.venue, groupId)) {
 				poco_error(Logger(), fmt::format("{}: No CGW group mapping for venue {}", SerialNumber, NewObject.venue));
+			} else {
+				PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{SerialNumber});
+				poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: groupID ({}), SerialNumber ({})", NewObject.venue, groupId, SerialNumber));
 			}
-			
-			PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{SerialNumber});
-			poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: SerialNumber ({})", NewObject.venue,SerialNumber));
 #endif
 			ProvObjects::InventoryTag NewTag;
 			DB_.GetRecord("id", NewObject.info.id, NewTag);

--- a/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
@@ -20,7 +20,9 @@
 #include "sdks/SDK_sec.h"
 #include <algorithm>
 #include <set>
-
+#ifdef CGW_INTEGRATION
+#include "InfraGroupEvents.h"
+#endif
 namespace OpenWifi {
 	void RESTAPI_sub_devices_handler::CleanupSubscriberConfigurationRecord(
 		const std::string &deviceConfiguration, const std::string &inventoryId) {
@@ -486,7 +488,7 @@ namespace OpenWifi {
 	}
 
 	bool RESTAPI_sub_devices_handler::CreateInventoryRecord(
-		const SubscriberDeviceDB::RecordName &newObject) {
+		const SubscriberDeviceDB::RecordName &newObject, std::string *venueID) {
 		poco_information(Logger(),
 						 fmt::format("[SUBSCRIBER_DEVICE_CREATE][CreateInventoryRecord]: start "
 									 "serial=[{}], subscriber=[{}], deviceConfiguration=[{}].",
@@ -553,6 +555,9 @@ namespace OpenWifi {
 										 inventoryRecord.info.id, inventoryRecord.venue,
 										 inventoryRecord.deviceConfiguration,
 										 inventoryRecord.subscriber));
+			if (venueID) {
+				*venueID = resolvedVenueId;
+			}
 			return true;
 		}
 
@@ -594,6 +599,9 @@ namespace OpenWifi {
 		poco_information(Logger(), fmt::format("[SUBSCRIBER_DEVICE_CREATE][CreateInventoryRecord]: "
 											   "completed serial=[{}], inventoryId=[{}].",
 											   newObject.serialNumber, inventoryRecord.info.id));
+		if (venueID) {
+			*venueID = resolvedVenueId;
+		}
 		return true;
 	}
 
@@ -619,7 +627,7 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_sub_devices_handler::DeleteInventoryForSubscriberDevice(
-		const ProvObjects::SubscriberDevice &existingObject) {
+		const ProvObjects::SubscriberDevice &existingObject, std::string *venueId) {
 		ProvObjects::InventoryTag inventoryRecord;
 		if (!StorageService()->InventoryDB().GetRecord("serialNumber", existingObject.serialNumber,
 													   inventoryRecord)) {
@@ -647,6 +655,9 @@ namespace OpenWifi {
 			return;
 		}
 		SerialNumberCache()->DeleteSerialNumber(existingObject.serialNumber);
+		if (venueId) {
+			*venueId = inventoryRecord.venue;
+		}
 	}
 
 	bool
@@ -808,13 +819,22 @@ namespace OpenWifi {
 			BadRequest(RESTAPI::Errors::NoRecordsDeleted);
 			return;
 		}
-		DeleteInventoryForSubscriberDevice(existingObject);
+		std::string venueID;
+		DeleteInventoryForSubscriberDevice(existingObject, &venueID);
 
 		if (!SDK::GW::Device::Delete(this, existingObject.serialNumber)) {
 			poco_warning(Logger(), fmt::format("[SUBSCRIBER_DEVICE_DELETE]: Failed to delete serial "
 											 "[{}] from owgw.",
 											 existingObject.serialNumber));
 		}
+#ifdef CGW_INTEGRATION
+		uint64_t groupId = -1;
+		if (!StorageService()->GroupsMapDB().GetGroup(venueID, groupId) ) {
+			poco_error(Logger(), fmt::format("Subscriber {} has no CGW groupsmap entry", venueID));
+		}
+		PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{existingObject.serialNumber});
+		poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: SerialNumber ({})", venueID,existingObject.serialNumber));
+#endif
 		return OK();
 	}
 
@@ -842,8 +862,8 @@ namespace OpenWifi {
 		if (!CreateSubscriberDeviceRecord(newObject)) {
 			return;
 		}
-
-		if (!CreateInventoryRecord(newObject)) {
+		std::string venueID;
+		if (!CreateInventoryRecord(newObject, &venueID)) {
 			if (!DB_.DeleteRecord("id", newObject.info.id)) {
 				poco_warning(Logger(), fmt::format("[SUBSCRIBER_DEVICE_CREATE]: Failed to rollback "
 												   "subscriber-device [{}] after inventory create "
@@ -876,6 +896,14 @@ namespace OpenWifi {
 									 newObject.subscriberId, newObject.serialNumber));
 		}
 
+#ifdef CGW_INTEGRATION
+		uint64_t groupId = -1;
+		if (!StorageService()->GroupsMapDB().GetGroup(venueID, groupId)) {
+			poco_error(Logger(), fmt::format("Subscriber {} has no CGW groupsmap entry", venueID));
+		}
+		PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{newObject.serialNumber});
+		poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: SerialNumber ({})", venueID,newObject.serialNumber));
+#endif
 		return ReturnSubscriberDeviceObject(newObject);
 	}
 

--- a/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
@@ -831,12 +831,13 @@ namespace OpenWifi {
 											 existingObject.serialNumber));
 		}
 #ifdef CGW_INTEGRATION
-		uint64_t groupId = -1;
+		std::uint32_t groupId = 0;
 		if (!StorageService()->GroupsMapDB().GetGroup(venueID, groupId) ) {
 			poco_error(Logger(), fmt::format("Subscriber {} has no CGW groupsmap entry", venueID));
+		} else {
+			PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{existingObject.serialNumber});
+			poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: groupID ({}), SerialNumber ({})", venueID, groupId, existingObject.serialNumber));
 		}
-		PublishInfraGroupEvent("infrastructure_group_infras_del", groupId,{existingObject.serialNumber});
-		poco_debug(Logger(), fmt::format("Message published for infra del VenueId {}: SerialNumber ({})", venueID,existingObject.serialNumber));
 #endif
 		return OK();
 	}
@@ -900,12 +901,13 @@ namespace OpenWifi {
 		}
 
 #ifdef CGW_INTEGRATION
-		uint64_t groupId = -1;
+		std::uint32_t groupId = 0;
 		if (!StorageService()->GroupsMapDB().GetGroup(venueID, groupId)) {
 			poco_error(Logger(), fmt::format("Subscriber {} has no CGW groupsmap entry", venueID));
+		} else {
+			PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{newObject.serialNumber});
+			poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: groupID ({}), SerialNumber ({})", venueID, groupId, newObject.serialNumber));
 		}
-		PublishInfraGroupEvent("infrastructure_group_infras_add", groupId,{newObject.serialNumber});
-		poco_debug(Logger(), fmt::format("Message published for infra add VenueId {}: SerialNumber ({})", venueID,newObject.serialNumber));
 #endif
 		return ReturnSubscriberDeviceObject(newObject);
 	}

--- a/src/RESTAPI/RESTAPI_sub_devices_handler.h
+++ b/src/RESTAPI/RESTAPI_sub_devices_handler.h
@@ -49,10 +49,11 @@ namespace OpenWifi {
 		bool ApplyPutRequest(const SubscriberDeviceDB::RecordName &updateObject,
 							 SubscriberDeviceDB::RecordName &existingObject,
 							 const Poco::JSON::Object::Ptr &rawObject);
-		bool CreateInventoryRecord(const SubscriberDeviceDB::RecordName &newObject);
+		bool CreateInventoryRecord(const SubscriberDeviceDB::RecordName &newObject,
+								   std::string *venueID = nullptr);
 		void CleanupInventoryAssociations(const ProvObjects::InventoryTag &inventoryRecord);
-		void
-		DeleteInventoryForSubscriberDevice(const ProvObjects::SubscriberDevice &existingObject);
+		void DeleteInventoryForSubscriberDevice(const ProvObjects::SubscriberDevice &existingObject,
+												std::string *venueId = nullptr);
 		bool CreateSubscriberDeviceRecord(const SubscriberDeviceDB::RecordName &newObject);
 		void ReturnSubscriberDeviceObject(const ProvObjects::SubscriberDevice &device);
 

--- a/src/RESTAPI/RESTAPI_subscriber_handler.cpp
+++ b/src/RESTAPI/RESTAPI_subscriber_handler.cpp
@@ -17,7 +17,9 @@
 #include "framework/orm.h"
 #include "framework/utils.h"
 #include "sdks/SDK_sec.h"
-
+#ifdef CGW_INTEGRATION
+#include "InfraGroupEvents.h"
+#endif
 namespace OpenWifi {
 
 	/*
@@ -208,7 +210,15 @@ namespace OpenWifi {
 				return InternalError(RESTAPI::Errors::RecordNotCreated);
 			}
 			StorageService()->EntityDB().AddVenue("id", SubscriberVenue.entity,
-												  SubscriberVenue.info.id);
+												  SubscriberVenue.info.id);				
+#ifdef CGW_INTEGRATION
+                uint64_t groupId = -1;
+                if (!StorageService()->GroupsMapDB().AddVenue(SubscriberVenue.info.id, groupId)) {
+                        poco_error(Logger(), fmt::format("Groupsmap Venue Creation DB failure {},groupID {}", SubscriberVenue.info.id,groupId));
+                }
+				PublishInfraGroupEvent("infrastructure_group_create", groupId);
+				poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", SubscriberVenue.info.id,groupId));
+#endif
 		}
 
 		Poco::JSON::Object SEAnswer;
@@ -349,7 +359,7 @@ namespace OpenWifi {
 									 subscriberId));
 			return BadRequest(RESTAPI::Errors::StillInUse);
 		}
-
+		//TODO : Need to make this idempotent or implement 2P-commit , also change this vector iteration.
 		VenueDB::RecordVec subscriberVenues;
 		if (StorageService()->VenueDB().GetRecords(
 				0, 100, subscriberVenues,
@@ -380,6 +390,18 @@ namespace OpenWifi {
 		if (!StorageService()->SignupDB().DeleteRecord("id", signupRecord.info.id)) {
 			return BadRequest(RESTAPI::Errors::NoRecordsDeleted);
 		}
+
+#ifdef CGW_INTEGRATION
+        uint64_t groupId = -1;
+        if (!StorageService()->GroupsMapDB().GetGroup(subscriberVenues[0].info.id, groupId)) {
+				poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", subscriberVenues[0].info.id, groupId));
+        }
+		PublishInfraGroupEvent("infrastructure_group_delete", groupId);
+        if (!StorageService()->GroupsMapDB().DeleteVenue(subscriberVenues[0].info.id)) {
+        		poco_error(Logger(), fmt::format("Delete Venue groupsmap delete failure {}, groupId {}", subscriberVenues[0].info.id, groupId));
+        }
+		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", subscriberVenues[0].info.id,groupId));
+#endif
 		return OK();
 	}
 

--- a/src/RESTAPI/RESTAPI_subscriber_handler.cpp
+++ b/src/RESTAPI/RESTAPI_subscriber_handler.cpp
@@ -212,12 +212,13 @@ namespace OpenWifi {
 			StorageService()->EntityDB().AddVenue("id", SubscriberVenue.entity,
 												  SubscriberVenue.info.id);				
 #ifdef CGW_INTEGRATION
-                uint64_t groupId = -1;
-                if (!StorageService()->GroupsMapDB().AddVenue(SubscriberVenue.info.id, groupId)) {
-                        poco_error(Logger(), fmt::format("Groupsmap Venue Creation DB failure {},groupID {}", SubscriberVenue.info.id,groupId));
-                }
-				PublishInfraGroupEvent("infrastructure_group_create", groupId);
-				poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", SubscriberVenue.info.id,groupId));
+				std::uint32_t groupId = 0;
+				if (!StorageService()->GroupsMapDB().AddVenue(SubscriberVenue.info.id, groupId)) {
+					poco_error(Logger(), fmt::format("Groupsmap Venue Creation DB failure {},groupID {}", SubscriberVenue.info.id,groupId));
+				} else {
+					PublishInfraGroupEvent("infrastructure_group_create", groupId);
+					poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", SubscriberVenue.info.id,groupId));
+				}
 #endif
 		}
 
@@ -392,15 +393,19 @@ namespace OpenWifi {
 		}
 
 #ifdef CGW_INTEGRATION
-        uint64_t groupId = -1;
-        if (!StorageService()->GroupsMapDB().GetGroup(subscriberVenues[0].info.id, groupId)) {
-				poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", subscriberVenues[0].info.id, groupId));
-        }
-		PublishInfraGroupEvent("infrastructure_group_delete", groupId);
-        if (!StorageService()->GroupsMapDB().DeleteVenue(subscriberVenues[0].info.id)) {
-        		poco_error(Logger(), fmt::format("Delete Venue groupsmap delete failure {}, groupId {}", subscriberVenues[0].info.id, groupId));
-        }
-		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", subscriberVenues[0].info.id,groupId));
+		if (!subscriberVenues.empty()) {
+			const auto &subscriberVenueId = subscriberVenues[0].info.id;
+			std::uint32_t groupId = 0;
+			if (!StorageService()->GroupsMapDB().GetGroup(subscriberVenueId, groupId)) {
+				poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", subscriberVenueId, groupId));
+			} else {
+				PublishInfraGroupEvent("infrastructure_group_delete", groupId);
+				if (!StorageService()->GroupsMapDB().DeleteVenue(subscriberVenueId)) {
+					poco_error(Logger(), fmt::format("Delete Venue groupsmap delete failure {}, groupId {}", subscriberVenueId, groupId));
+				}
+				poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", subscriberVenueId,groupId));
+			}
+		}
 #endif
 		return OK();
 	}

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -18,6 +18,9 @@
 #include "framework/MicroServiceFuncs.h"
 
 #include "Kafka_ProvUpdater.h"
+#ifdef CGW_INTEGRATION
+#include "InfraGroupEvents.h"
+#endif
 
 namespace OpenWifi {
 
@@ -113,6 +116,17 @@ namespace OpenWifi {
 		if (!Existing.entity.empty())
 			StorageService()->EntityDB().DeleteVenue("id", Existing.entity, UUID);
 		DB_.DeleteRecord("id", UUID);
+#ifdef CGW_INTEGRATION
+        uint64_t groupId = -1;
+        if (!StorageService()->GroupsMapDB().GetGroup(UUID, groupId)) {
+			poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", UUID));
+        }
+		PublishInfraGroupEvent("infrastructure_group_delete", groupId);
+		if (!StorageService()->GroupsMapDB().DeleteVenue(UUID)) {
+            poco_error(Logger(), fmt::format("Delete groupsmap delete failure {}, groupId {}", UUID));
+        }
+		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", UUID,groupId));
+#endif
 
 		UpdateKafkaProvisioningObject(ProvisioningOperation::removal, Existing);
 
@@ -203,6 +217,15 @@ namespace OpenWifi {
 			return BadRequest(RESTAPI::Errors::InternalError);
 		}
 
+#ifdef CGW_INTEGRATION
+                uint64_t groupId = -1;
+                if (!StorageService()->GroupsMapDB().AddVenue(NewObject.info.id, groupId)) {
+                        poco_error(Logger(), fmt::format("Groupsmap Venue creation failure {}, groupId {}", NewObject.info.id,groupId));
+                        return InternalError(RESTAPI::Errors::RecordNotCreated);
+                }
+				PublishInfraGroupEvent("infrastructure_group_create", groupId);
+				poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", NewObject.info.id,groupId));
+#endif
 		if (DB_.CreateRecord(NewObject)) {
 			MoveUsage(StorageService()->ContactDB(), DB_, {}, NewObject.contacts,
 					  NewObject.info.id);

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -218,16 +218,21 @@ namespace OpenWifi {
 			return BadRequest(RESTAPI::Errors::InternalError);
 		}
 
-#ifdef CGW_INTEGRATION
-		std::uint32_t groupId = 0;
-		if (!StorageService()->GroupsMapDB().AddVenue(NewObject.info.id, groupId)) {
-			poco_error(Logger(), fmt::format("Groupsmap Venue creation failure {}, groupId {}", NewObject.info.id,groupId));
-			return InternalError(RESTAPI::Errors::RecordNotCreated);
-		}
-		PublishInfraGroupEvent("infrastructure_group_create", groupId);
-		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", NewObject.info.id,groupId));
-#endif
 		if (DB_.CreateRecord(NewObject)) {
+#ifdef CGW_INTEGRATION
+			std::uint32_t groupId = 0;
+			if (!StorageService()->GroupsMapDB().AddVenue(NewObject.info.id, groupId)) {
+				poco_error(Logger(), fmt::format("Groupsmap Venue creation failure {}, groupId {}",
+												 NewObject.info.id, groupId));
+				// Do not fail the entire request if the groupsmap entry creation fails
+			} else {
+				PublishInfraGroupEvent("infrastructure_group_create", groupId);
+				poco_debug(Logger(),
+						   fmt::format("Message published for infrastructure_group_create VenueId "
+									   "{}: groupID ({})",
+									   NewObject.info.id, groupId));
+			}
+#endif
 			MoveUsage(StorageService()->ContactDB(), DB_, {}, NewObject.contacts,
 					  NewObject.info.id);
 			MoveUsage(StorageService()->LocationDB(), DB_, "", NewObject.location,

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -117,15 +117,16 @@ namespace OpenWifi {
 			StorageService()->EntityDB().DeleteVenue("id", Existing.entity, UUID);
 		DB_.DeleteRecord("id", UUID);
 #ifdef CGW_INTEGRATION
-        uint64_t groupId = -1;
-        if (!StorageService()->GroupsMapDB().GetGroup(UUID, groupId)) {
-			poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", UUID));
-        }
-		PublishInfraGroupEvent("infrastructure_group_delete", groupId);
+		std::uint32_t groupId = 0;
+		if (!StorageService()->GroupsMapDB().GetGroup(UUID, groupId)) {
+			poco_error(Logger(), fmt::format("Delete Venue groupsmap lookup failure {}, groupId {}", UUID, groupId));
+		} else {
+			PublishInfraGroupEvent("infrastructure_group_delete", groupId);
+			poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", UUID,groupId));
+		}
 		if (!StorageService()->GroupsMapDB().DeleteVenue(UUID)) {
-            poco_error(Logger(), fmt::format("Delete groupsmap delete failure {}, groupId {}", UUID));
-        }
-		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_delete VenueId {}: groupID ({})", UUID,groupId));
+			poco_error(Logger(), fmt::format("Delete groupsmap delete failure {}, groupId {}", UUID, groupId));
+		}
 #endif
 
 		UpdateKafkaProvisioningObject(ProvisioningOperation::removal, Existing);
@@ -218,13 +219,13 @@ namespace OpenWifi {
 		}
 
 #ifdef CGW_INTEGRATION
-                uint64_t groupId = -1;
-                if (!StorageService()->GroupsMapDB().AddVenue(NewObject.info.id, groupId)) {
-                        poco_error(Logger(), fmt::format("Groupsmap Venue creation failure {}, groupId {}", NewObject.info.id,groupId));
-                        return InternalError(RESTAPI::Errors::RecordNotCreated);
-                }
-				PublishInfraGroupEvent("infrastructure_group_create", groupId);
-				poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", NewObject.info.id,groupId));
+		std::uint32_t groupId = 0;
+		if (!StorageService()->GroupsMapDB().AddVenue(NewObject.info.id, groupId)) {
+			poco_error(Logger(), fmt::format("Groupsmap Venue creation failure {}, groupId {}", NewObject.info.id,groupId));
+			return InternalError(RESTAPI::Errors::RecordNotCreated);
+		}
+		PublishInfraGroupEvent("infrastructure_group_create", groupId);
+		poco_debug(Logger(), fmt::format("Message published for infrastructure_group_create VenueId {}: groupID ({})", NewObject.info.id,groupId));
 #endif
 		if (DB_.CreateRecord(NewObject)) {
 			MoveUsage(StorageService()->ContactDB(), DB_, {}, NewObject.contacts,

--- a/src/StorageService.cpp
+++ b/src/StorageService.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 //	License type: BSD 3-Clause License
 //	License copy: https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/LICENSE
@@ -44,7 +49,9 @@ namespace OpenWifi {
         GLBLRCertsDB_ = std::make_unique<OpenWifi::GLBLRCertsDB>(dbType_, *Pool_, Logger());
         OrionAccountsDB_ = std::make_unique<OpenWifi::OrionAccountsDB>(dbType_, *Pool_, Logger());
         RadiusEndpointDB_ = std::make_unique<OpenWifi::RadiusEndpointDB>(dbType_, *Pool_, Logger());
-
+#ifdef CGW_INTEGRATION
+        GroupsMapDB_ = std::make_unique<OpenWifi::GroupsMapDB>(dbType_, *Pool_, Logger());
+#endif
 		EntityDB_->Create();
 		PolicyDB_->Create();
 		VenueDB_->Create();
@@ -68,7 +75,9 @@ namespace OpenWifi {
         GLBLRCertsDB_->Create();
         OrionAccountsDB_->Create();
         RadiusEndpointDB_->Create();
-
+#ifdef CGW_INTEGRATION
+        GroupsMapDB_->Create();
+#endif
 		ExistFunc_[EntityDB_->Prefix()] = [=](const char *F, std::string &V) -> bool {
 			return EntityDB_->Exists(F, V);
 		};
@@ -138,7 +147,11 @@ namespace OpenWifi {
         ExistFunc_[RadiusEndpointDB_->Prefix()] = [=](const char *F, std::string &V) -> bool {
             return RadiusEndpointDB_->Exists(F, V);
         };
-
+#ifdef CGW_INTEGRATION
+        ExistFunc_[GroupsMapDB_->Prefix()] = [=](const char *F, std::string &V) -> bool {
+            return GroupsMapDB_->Exists(F, V);
+        };
+#endif
 
 
         ExpandFunc_[EntityDB_->Prefix()] = [=](const char *F, std::string &V, std::string &Name,

--- a/src/StorageService.h
+++ b/src/StorageService.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 //	License type: BSD 3-Clause License
 //	License copy: https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/LICENSE
@@ -35,6 +40,9 @@
 
 #include "Poco/URI.h"
 #include "framework/ow_constants.h"
+#ifdef CGW_INTEGRATION
+#include "storage/storage_groupsmap.h"
+#endif
 
 namespace OpenWifi {
 
@@ -74,7 +82,9 @@ namespace OpenWifi {
         inline OpenWifi::GLBLRCertsDB &GLBLRCertsDB() { return *GLBLRCertsDB_; }
         inline OpenWifi::OrionAccountsDB &OrionAccountsDB() { return *OrionAccountsDB_; }
         inline OpenWifi::RadiusEndpointDB &RadiusEndpointDB() { return *RadiusEndpointDB_; }
-
+#ifdef CGW_INTEGRATION
+        inline OpenWifi::GroupsMapDB &GroupsMapDB() { return *GroupsMapDB_; }
+#endif
 		bool Validate(const Poco::URI::QueryParameters &P, RESTAPI::Errors::msg &Error);
 		bool Validate(const Types::StringVec &P, std::string &Error);
 		inline bool ValidatePrefix(const std::string &P) const {
@@ -137,6 +147,9 @@ namespace OpenWifi {
         std::unique_ptr<OpenWifi::GLBLRCertsDB> GLBLRCertsDB_;
         std::unique_ptr<OpenWifi::OrionAccountsDB> OrionAccountsDB_;
         std::unique_ptr<OpenWifi::RadiusEndpointDB> RadiusEndpointDB_;
+#ifdef CGW_INTEGRATION
+        std::unique_ptr<OpenWifi::GroupsMapDB> GroupsMapDB_;
+#endif
 		std::string DefaultOperator_;
 
 		typedef std::function<bool(const char *FieldName, std::string &Value)> exist_func;

--- a/src/framework/KafkaTopics.h
+++ b/src/framework/KafkaTopics.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 //	License type: BSD 3-Clause License
 //	License copy: https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/LICENSE
@@ -21,6 +26,10 @@ namespace OpenWifi::KafkaTopics {
 	inline const char * DEVICE_TELEMETRY = "device_telemetry";
 	inline const char * PROVISIONING_CHANGE = "provisioning_change";
 	inline const char * RRM = "rrm";
+	//This is new topic on KAFKA introduced for subscriber creation/deletion messages  
+#ifdef CGW_INTEGRATION
+	inline const char * CNC = "CnC";
+#endif
 
 	namespace ServiceEvents {
 		inline const char * EVENT_JOIN = "join";

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -439,6 +439,30 @@ namespace ORM {
 			return false;
 		}
 
+		bool CreateRecord(const RecordType &R, uint64_t &out_id) {
+#ifdef CGW_INTEGRATION
+			if (TableName_ == "groupsmap" && Type_ == OpenWifi::DBType::pgsql) {
+				try {
+					Poco::Data::Session Session = Pool_.get();
+					RecordTuple RT;
+					Convert(R, RT);
+					std::string venueId = RT.template get<0>();
+					Poco::Data::Statement Insert(Session);
+					std::string St = "insert into " + TableName_ +
+									 " (venueid) values (?) returning groupid";
+					Insert << ConvertParams(St),
+						Poco::Data::Keywords::use(venueId),
+						Poco::Data::Keywords::into(out_id), Poco::Data::Keywords::now;
+					return true;
+				} catch (const Poco::Exception &E) {
+					Logger_.log(E);
+					return false;
+				}
+			}
+#endif
+			return false;
+		}
+
 		template <typename T>
 		bool GetRecord(field_name_t FieldName, const T &Value, RecordType &R) {
 			try {

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -439,30 +439,6 @@ namespace ORM {
 			return false;
 		}
 
-		bool CreateRecord(const RecordType &R, uint64_t &out_id) {
-#ifdef CGW_INTEGRATION
-			if (TableName_ == "groupsmap" && Type_ == OpenWifi::DBType::pgsql) {
-				try {
-					Poco::Data::Session Session = Pool_.get();
-					RecordTuple RT;
-					Convert(R, RT);
-					std::string venueId = RT.template get<0>();
-					Poco::Data::Statement Insert(Session);
-					std::string St = "insert into " + TableName_ +
-									 " (venueid) values (?) returning groupid";
-					Insert << ConvertParams(St),
-						Poco::Data::Keywords::use(venueId),
-						Poco::Data::Keywords::into(out_id), Poco::Data::Keywords::now;
-					return true;
-				} catch (const Poco::Exception &E) {
-					Logger_.log(E);
-					return false;
-				}
-			}
-#endif
-			return false;
-		}
-
 		template <typename T>
 		bool GetRecord(field_name_t FieldName, const T &Value, RecordType &R) {
 			try {

--- a/src/storage/storage_groupsmap.cpp
+++ b/src/storage/storage_groupsmap.cpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+#ifdef CGW_INTEGRATION
+#include "storage_groupsmap.h"
+#include "Poco/Data/Statement.h"
+#include "Poco/Data/Session.h"
+#include "Poco/Logger.h"
+
+namespace OpenWifi {
+    static ORM::FieldVec GroupsMapDB_Fields{
+        ORM::Field{"venueid", ORM::FieldType::FT_TEXT, 64},
+        ORM::Field{"groupid", ORM::FieldType::FT_BIGINT, 0, true}
+    };
+    static ORM::IndexVec GroupsMapDB_Indexes{
+        {std::string{"groupsmap_venue_idx"}, ORM::IndexEntryVec{{std::string{"venueid"}, ORM::Indextype::ASC}}}
+    };
+
+    GroupsMapDB::GroupsMapDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
+        : DB(T, "groupsmap", GroupsMapDB_Fields, GroupsMapDB_Indexes, P, L, "gmap") {}
+
+    bool GroupsMapDB::Create() {
+        try {
+            Poco::Data::Session Session = Pool_.get();
+            if (Type_ != OpenWifi::DBType::pgsql) {
+                poco_error(Logger(), "GroupsMapDB::Create requires PostgreSQL.");
+                return false;
+            }
+            std::string Statement =
+                "create table if not exists " + TableName_ +
+                " ( venueid TEXT, groupid BIGSERIAL PRIMARY KEY )";
+            Session << Statement, Poco::Data::Keywords::now;
+            Session << "create index if not exists groupsmap_venue_idx on " + TableName_ +
+                               " ( venueid ASC )",
+                Poco::Data::Keywords::now;
+        } catch (const std::exception &E) {
+            poco_error(Logger(), fmt::format("Exception in GroupsMapDB::Create {}", E.what()));
+        }
+        return Upgrade();
+    }
+
+    bool GroupsMapDB::AddVenue(const std::string &venueId, uint64_t &groupId) {
+        GroupsMapRecord R;
+        R.venueid = venueId;
+        if (!ORM::DB<GroupsMapDBRecordType, GroupsMapRecord>::CreateRecord(R, groupId))
+            return false;
+        poco_debug(Logger(), fmt::format("Added venue {} with group id {}", venueId, groupId));
+        return true;
+    }
+
+    bool GroupsMapDB::GetGroup(const std::string &venueId, uint64_t &groupId) {
+        GroupsMapRecord rec;
+        if (GetRecord("venueid", venueId, rec)) {
+            groupId = rec.groupid;
+            return true;
+        }
+        return false;
+    }
+
+    bool GroupsMapDB::DeleteVenue(const std::string &venueId) {
+        bool ok = DeleteRecord("venueid", venueId);
+        return ok;
+    }
+} // namespace OpenWifi
+
+template<> void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(const OpenWifi::GroupsMapDBRecordType &In, OpenWifi::GroupsMapRecord &Out) {
+    Out.venueid = In.get<0>();
+    Out.groupid = In.get<1>();
+}
+
+template<> void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(const OpenWifi::GroupsMapRecord &In, OpenWifi::GroupsMapDBRecordType &Out) {
+    Out.set<0>(In.venueid);
+    Out.set<1>(In.groupid);
+}
+#endif

--- a/src/storage/storage_groupsmap.cpp
+++ b/src/storage/storage_groupsmap.cpp
@@ -27,16 +27,17 @@ namespace OpenWifi {
 				return false;
 			}
 
-				std::string statement = "create table if not exists " + TableName_ +
-										" ( venueid TEXT, groupid SERIAL PRIMARY KEY )";
-				Session << statement, Poco::Data::Keywords::now;
-				Session << "create unique index if not exists groupsmap_venue_uidx on " + TableName_ +
-							   " ( venueid ASC )",
-					Poco::Data::Keywords::now;
+			std::string statement = "create table if not exists " + TableName_ +
+									" ( venueid TEXT, groupid SERIAL PRIMARY KEY )";
+			Session << statement, Poco::Data::Keywords::now;
+			Session << "create unique index if not exists groupsmap_venue_uidx on " + TableName_ +
+						   " ( venueid ASC )",
+				Poco::Data::Keywords::now;
 		} catch (const std::exception &E) {
 			poco_error(Logger(), fmt::format("Exception in GroupsMapDB::Create {}", E.what()));
+			return false;
 		}
-		return Upgrade();
+		return Upgrade(); // Returns its result (so final success/failure comes from Upgrade).
 	}
 
 	bool GroupsMapDB::AddVenue(const std::string &venueId, std::uint32_t &groupId) {
@@ -48,23 +49,16 @@ namespace OpenWifi {
 
 			Poco::Data::Session Session = Pool_.get();
 			Poco::Data::Statement Insert(Session);
-			std::uint64_t generatedGroupId = 0;
 			std::string venueIdParam = venueId;
+			groupId = 0;
 			std::string statement = "insert into " + TableName_ +
 									" (venueid) values (?) "
 									"on conflict (venueid) do update set venueid=excluded.venueid "
 									"returning groupid";
 
 			Insert << ConvertParams(statement), Poco::Data::Keywords::use(venueIdParam),
-				Poco::Data::Keywords::into(generatedGroupId), Poco::Data::Keywords::now;
+				Poco::Data::Keywords::into(groupId), Poco::Data::Keywords::now;
 
-			if (generatedGroupId > std::numeric_limits<std::uint32_t>::max()) {
-				poco_error(Logger(), fmt::format("groupsmap groupid {} exceeds uint32 for venue {}",
-												 generatedGroupId, venueId));
-				return false;
-			}
-
-			groupId = static_cast<std::uint32_t>(generatedGroupId);
 			poco_debug(Logger(),
 					   fmt::format("Upserted venue {} with group id {}", venueId, groupId));
 			return true;
@@ -73,6 +67,7 @@ namespace OpenWifi {
 		}
 		return false;
 	}
+
 
 	bool GroupsMapDB::GetGroup(const std::string &venueId, std::uint32_t &groupId) {
 		GroupsMapRecord rec;

--- a/src/storage/storage_groupsmap.cpp
+++ b/src/storage/storage_groupsmap.cpp
@@ -5,73 +5,101 @@
  */
 #ifdef CGW_INTEGRATION
 #include "storage_groupsmap.h"
-#include "Poco/Data/Statement.h"
+#include <limits>
+
 #include "Poco/Data/Session.h"
+#include "Poco/Data/Statement.h"
 #include "Poco/Logger.h"
 
 namespace OpenWifi {
-    static ORM::FieldVec GroupsMapDB_Fields{
-        ORM::Field{"venueid", ORM::FieldType::FT_TEXT, 64},
-        ORM::Field{"groupid", ORM::FieldType::FT_BIGINT, 0, true}
-    };
-    static ORM::IndexVec GroupsMapDB_Indexes{
-        {std::string{"groupsmap_venue_idx"}, ORM::IndexEntryVec{{std::string{"venueid"}, ORM::Indextype::ASC}}}
-    };
+	static ORM::FieldVec GroupsMapDB_Fields{ORM::Field{"venueid", ORM::FieldType::FT_TEXT, 64},
+											ORM::Field{"groupid", ORM::FieldType::FT_INT, 0, true}};
+	static ORM::IndexVec GroupsMapDB_Indexes{};
 
-    GroupsMapDB::GroupsMapDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
-        : DB(T, "groupsmap", GroupsMapDB_Fields, GroupsMapDB_Indexes, P, L, "gmap") {}
+	GroupsMapDB::GroupsMapDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
+		: DB(T, "groupsmap", GroupsMapDB_Fields, GroupsMapDB_Indexes, P, L, "gmap") {}
 
-    bool GroupsMapDB::Create() {
-        try {
-            Poco::Data::Session Session = Pool_.get();
-            if (Type_ != OpenWifi::DBType::pgsql) {
-                poco_error(Logger(), "GroupsMapDB::Create requires PostgreSQL.");
-                return false;
-            }
-            std::string Statement =
-                "create table if not exists " + TableName_ +
-                " ( venueid TEXT, groupid BIGSERIAL PRIMARY KEY )";
-            Session << Statement, Poco::Data::Keywords::now;
-            Session << "create index if not exists groupsmap_venue_idx on " + TableName_ +
-                               " ( venueid ASC )",
-                Poco::Data::Keywords::now;
-        } catch (const std::exception &E) {
-            poco_error(Logger(), fmt::format("Exception in GroupsMapDB::Create {}", E.what()));
-        }
-        return Upgrade();
-    }
+	bool GroupsMapDB::Create() {
+		try {
+			Poco::Data::Session Session = Pool_.get();
+			if (Type_ != OpenWifi::DBType::pgsql) {
+				poco_error(Logger(), "GroupsMapDB::Create requires PostgreSQL.");
+				return false;
+			}
 
-    bool GroupsMapDB::AddVenue(const std::string &venueId, uint64_t &groupId) {
-        GroupsMapRecord R;
-        R.venueid = venueId;
-        if (!ORM::DB<GroupsMapDBRecordType, GroupsMapRecord>::CreateRecord(R, groupId))
-            return false;
-        poco_debug(Logger(), fmt::format("Added venue {} with group id {}", venueId, groupId));
-        return true;
-    }
+				std::string statement = "create table if not exists " + TableName_ +
+										" ( venueid TEXT, groupid SERIAL PRIMARY KEY )";
+				Session << statement, Poco::Data::Keywords::now;
+				Session << "create unique index if not exists groupsmap_venue_uidx on " + TableName_ +
+							   " ( venueid ASC )",
+					Poco::Data::Keywords::now;
+		} catch (const std::exception &E) {
+			poco_error(Logger(), fmt::format("Exception in GroupsMapDB::Create {}", E.what()));
+		}
+		return Upgrade();
+	}
 
-    bool GroupsMapDB::GetGroup(const std::string &venueId, uint64_t &groupId) {
-        GroupsMapRecord rec;
-        if (GetRecord("venueid", venueId, rec)) {
-            groupId = rec.groupid;
-            return true;
-        }
-        return false;
-    }
+	bool GroupsMapDB::AddVenue(const std::string &venueId, std::uint32_t &groupId) {
+		try {
+			if (Type_ != OpenWifi::DBType::pgsql) {
+				poco_error(Logger(), "GroupsMapDB::AddVenue requires PostgreSQL.");
+				return false;
+			}
 
-    bool GroupsMapDB::DeleteVenue(const std::string &venueId) {
-        bool ok = DeleteRecord("venueid", venueId);
-        return ok;
-    }
+			Poco::Data::Session Session = Pool_.get();
+			Poco::Data::Statement Insert(Session);
+			std::uint64_t generatedGroupId = 0;
+			std::string venueIdParam = venueId;
+			std::string statement = "insert into " + TableName_ +
+									" (venueid) values (?) "
+									"on conflict (venueid) do update set venueid=excluded.venueid "
+									"returning groupid";
+
+			Insert << ConvertParams(statement), Poco::Data::Keywords::use(venueIdParam),
+				Poco::Data::Keywords::into(generatedGroupId), Poco::Data::Keywords::now;
+
+			if (generatedGroupId > std::numeric_limits<std::uint32_t>::max()) {
+				poco_error(Logger(), fmt::format("groupsmap groupid {} exceeds uint32 for venue {}",
+												 generatedGroupId, venueId));
+				return false;
+			}
+
+			groupId = static_cast<std::uint32_t>(generatedGroupId);
+			poco_debug(Logger(),
+					   fmt::format("Upserted venue {} with group id {}", venueId, groupId));
+			return true;
+		} catch (const Poco::Exception &E) {
+			Logger().log(E);
+		}
+		return false;
+	}
+
+	bool GroupsMapDB::GetGroup(const std::string &venueId, std::uint32_t &groupId) {
+		GroupsMapRecord rec;
+		if (GetRecord("venueid", venueId, rec)) {
+			groupId = rec.groupid;
+			return true;
+		}
+		return false;
+	}
+
+	bool GroupsMapDB::DeleteVenue(const std::string &venueId) {
+		bool ok = DeleteRecord("venueid", venueId);
+		return ok;
+	}
 } // namespace OpenWifi
 
-template<> void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(const OpenWifi::GroupsMapDBRecordType &In, OpenWifi::GroupsMapRecord &Out) {
-    Out.venueid = In.get<0>();
-    Out.groupid = In.get<1>();
+template <>
+void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(
+	const OpenWifi::GroupsMapDBRecordType &In, OpenWifi::GroupsMapRecord &Out) {
+	Out.venueid = In.get<0>();
+	Out.groupid = In.get<1>();
 }
 
-template<> void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(const OpenWifi::GroupsMapRecord &In, OpenWifi::GroupsMapDBRecordType &Out) {
-    Out.set<0>(In.venueid);
-    Out.set<1>(In.groupid);
+template <>
+void ORM::DB<OpenWifi::GroupsMapDBRecordType, OpenWifi::GroupsMapRecord>::Convert(
+	const OpenWifi::GroupsMapRecord &In, OpenWifi::GroupsMapDBRecordType &Out) {
+	Out.set<0>(In.venueid);
+	Out.set<1>(In.groupid);
 }
 #endif

--- a/src/storage/storage_groupsmap.h
+++ b/src/storage/storage_groupsmap.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+#pragma once
+#ifdef CGW_INTEGRATION
+#include "framework/orm.h"
+
+namespace OpenWifi {
+    struct GroupsMapRecord {
+        std::string venueid;
+        uint64_t groupid = 0;
+    };
+
+    typedef Poco::Tuple<std::string, uint64_t> GroupsMapDBRecordType;
+
+    class GroupsMapDB : public ORM::DB<GroupsMapDBRecordType, GroupsMapRecord> {
+      public:
+        GroupsMapDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L);
+        /**
+         * @brief Create the groupsmap table with an auto-incrementing group id.
+         */
+        bool Create();
+        /**
+         * @brief Create a new mapping entry for the provided venue id.
+         *
+         * Generates a new group id, persists the mapping and returns the id via
+         * the output parameter.
+         *
+         * @param venueId provisioning venue identifier.
+         * @param groupId populated with the newly allocated group id when the call succeeds.
+         * @return true on successful persistence, false otherwise.
+         */
+        bool AddVenue(const std::string &venueId, uint64_t &groupId);
+        /**
+         * @brief Lookup the CGW group id associated with the given venue.
+         *
+         * @param venueId provisioning venue identifier.
+         * @param groupId mapped Id for CGW.
+         * @return true if a mapping exists, false if none is found or an error occurs.
+         */
+        bool GetGroup(const std::string &venueId, uint64_t &groupId);
+        /**
+         * @brief Remove the mapping entry for the specified venue.
+         *
+         * @param venueId provisioning venue identifier.
+         * @return true when the entry is deleted, false if the record does not exist or deletion fails.
+         */
+        bool DeleteVenue(const std::string &venueId);
+      private:
+    };
+}
+#endif

--- a/src/storage/storage_groupsmap.h
+++ b/src/storage/storage_groupsmap.h
@@ -5,22 +5,21 @@
  */
 #pragma once
 #ifdef CGW_INTEGRATION
+#include <cstdint>
+
 #include "framework/orm.h"
 
 namespace OpenWifi {
     struct GroupsMapRecord {
         std::string venueid;
-        uint64_t groupid = 0;
+        std::uint32_t groupid = 0;
     };
 
-    typedef Poco::Tuple<std::string, uint64_t> GroupsMapDBRecordType;
+    typedef Poco::Tuple<std::string, std::uint32_t> GroupsMapDBRecordType;
 
     class GroupsMapDB : public ORM::DB<GroupsMapDBRecordType, GroupsMapRecord> {
       public:
         GroupsMapDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L);
-        /**
-         * @brief Create the groupsmap table with an auto-incrementing group id.
-         */
         bool Create();
         /**
          * @brief Create a new mapping entry for the provided venue id.
@@ -32,7 +31,7 @@ namespace OpenWifi {
          * @param groupId populated with the newly allocated group id when the call succeeds.
          * @return true on successful persistence, false otherwise.
          */
-        bool AddVenue(const std::string &venueId, uint64_t &groupId);
+        bool AddVenue(const std::string &venueId, std::uint32_t &groupId);
         /**
          * @brief Lookup the CGW group id associated with the given venue.
          *
@@ -40,7 +39,7 @@ namespace OpenWifi {
          * @param groupId mapped Id for CGW.
          * @return true if a mapping exists, false if none is found or an error occurs.
          */
-        bool GetGroup(const std::string &venueId, uint64_t &groupId);
+        bool GetGroup(const std::string &venueId, std::uint32_t &groupId);
         /**
          * @brief Remove the mapping entry for the specified venue.
          *


### PR DESCRIPTION
Enabled Kafka-based CnC event publishing for subscriber and venue lifecycle events, including device attach/detach operations.

**Kafka Integration**
Publish messages to the CnC Kafka topic for:
- Subscriber creation/deletion
- Venue creation/deletion
- Device attach/detach operations

**Database Updates**
- Introduced a new table(groupmaps) to map: groupId -> venueId
- This mapping is used for CGW infrastructure tracking
