### PR TITLE
[SUBSCRIBER-DEVICE]:stop duplicate configure and allow OLG updates

### DIFF
--- a/src/AutoDiscovery.cpp
+++ b/src/AutoDiscovery.cpp
@@ -5,7 +5,6 @@
 #include "AutoDiscovery.h"
 #include "Poco/JSON/Parser.h"
 #include "StorageService.h"
-#include "Tasks/VenueConfigUpdater.h"
 #include "framework/KafkaManager.h"
 #include "framework/KafkaTopics.h"
 #include "framework/ow_constants.h"
@@ -108,11 +107,6 @@ namespace OpenWifi {
                         if (!SerialNumber.empty() && Connected) {
                             StorageService()->InventoryDB().CreateFromConnection(
                                     SerialNumber, ConnectedIP, Compatible, Locale, isConnection);
-                            // Now that the entry has been created, we can try to push a config if
-                            // the connection was a capabilities message.
-                            if (isConnection){
-                                ComputeAndPushConfig(SerialNumber, Compatible, Logger());
-                            }
                         }
                     }
 				} catch (const Poco::Exception &E) {

--- a/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_sub_devices_handler.cpp
@@ -429,14 +429,17 @@ namespace OpenWifi {
 			return true;
 		}
 
-		const auto subscriberDeviceCount =
-			DB_.Count(DB_.OP("subscriberId", ORM::EQ, existingObject.subscriberId));
-		if (subscriberDeviceCount > 1) {
+		const auto targetSubscriberId =
+			updateObject.subscriberId.empty() ? existingObject.subscriberId : updateObject.subscriberId;
+		const auto otherOlgCount = DB_.Count(fmt::format(
+			" subscriberId='{}' and lower(deviceGroup)='olg' and id!='{}' ",
+			ORM::Escape(targetSubscriberId), ORM::Escape(existingObject.info.id)));
+		if (otherOlgCount > 0) {
 			poco_warning(Logger(), fmt::format("[SUBSCRIBER_DEVICE_UPDATE]: Rejecting serial [{}]. "
-											   "Only first device can be olg. subscriber [{}], "
-											   "device count [{}].",
-											   existingObject.serialNumber, existingObject.subscriberId,
-											   subscriberDeviceCount));
+											   "Only one OLG device is allowed per subscriber. "
+											   "subscriber [{}], other OLG count [{}].",
+											   existingObject.serialNumber, targetSubscriberId,
+											   otherOlgCount));
 			BadRequest(RESTAPI::Errors::OnlyFirstSubscriberDeviceCanBeOLG);
 			return false;
 		}

--- a/src/storage/storage_inventory.cpp
+++ b/src/storage/storage_inventory.cpp
@@ -190,24 +190,19 @@ namespace OpenWifi {
 															 ExistingDevice);
 			}
 
-			// Push entity and venue down to GW but only on connect (not ping)
-			if (isConnection && !ExistingDevice.venue.empty()) {
-				if (SDK::GW::Device::SetVenue(nullptr, ExistingDevice.serialNumber, ExistingDevice.venue)) {
-						Logger().information(Poco::format("%s: GW set venue property.",
-														  ExistingDevice.serialNumber));
+			// Push ownership properties in a single GW PUT, only on connect (not ping).
+			if (isConnection && (!ExistingDevice.venue.empty() || !ExistingDevice.entity.empty() ||
+								 !ExistingDevice.subscriber.empty())) {
+				if (SDK::GW::Device::SetOwnerShip(nullptr, ExistingDevice.serialNumber,
+												  ExistingDevice.entity, ExistingDevice.venue,
+												  ExistingDevice.subscriber)) {
+					Logger().information(
+						Poco::format("%s: GW set ownership properties (entity/venue/subscriber).",
+									 ExistingDevice.serialNumber));
 				} else {
 					Logger().information(Poco::format(
-						"%s: could not set GW venue property.", ExistingDevice.serialNumber));
-				}
-			}
-
-			if (isConnection && !ExistingDevice.entity.empty()) {
-				if (SDK::GW::Device::SetEntity(nullptr, ExistingDevice.serialNumber, ExistingDevice.entity)) {
-						Logger().information(Poco::format("%s: GW set entity property.",
-														  ExistingDevice.serialNumber));
-				} else {
-					Logger().information(Poco::format(
-						"%s: could not set GW entity property.", ExistingDevice.serialNumber));
+						"%s: could not set GW ownership properties (entity/venue/subscriber).",
+						ExistingDevice.serialNumber));
 				}
 			}
 


### PR DESCRIPTION
## Summary
This PR fixes subscriber-device sync issues between Provisioning and Gateway:

- Stop AutoDiscovery from triggering config push on `capabilities` connect events.
- Use a single ownership update call (`entity/venue/subscriber`) for existing devices on connect.
- Fix OLG update validation so valid updates to an existing OLG device are allowed.

## Bugs fixed

### 1) Duplicate configure on device connect
**Bug:** AutoDiscovery was triggering config push during `capabilities` processing, causing duplicate/unnecessary configure attempts in normal connect flow.  
**Fix:** Removed config push from
