### PR TITLE
Return correct error when operator registration-ID already exists

### DIFF
--- a/src/RESTAPI/RESTAPI_operators_handler.cpp
+++ b/src/RESTAPI/RESTAPI_operators_handler.cpp
@@ -120,9 +120,12 @@ namespace OpenWifi {
 		}
 
 		Poco::toLowerInPlace(NewObject.registrationId);
-		if (NewObject.registrationId.empty() ||
-			DB_.Exists("registrationId", NewObject.registrationId)) {
+		if (NewObject.registrationId.empty()) {
 			return BadRequest(RESTAPI::Errors::InvalidRegistrationOperatorName);
+		}
+
+		if (DB_.Exists("registrationId", NewObject.registrationId)) {
+			return BadRequest(RESTAPI::Errors::RegistrationIdAlreadyExists);
 		}
 
 		if (RawObject->has("entityId")) {

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -457,6 +457,9 @@ namespace OpenWifi::RESTAPI::Errors {
 		1199, "This venue is linked to a subscriber. Add devices only from the Subscriber page."
 	};
 
+	static const struct msg RegistrationIdAlreadyExists {
+		1200, "An operator with this registration-ID already exists."
+	};
     static const struct msg SimulationDoesNotExist {
         7000, "Simulation Instance ID does not exist."
     };


### PR DESCRIPTION
 **Problem Fixed:-**

- Creating an operator with a registration ID that already exists was returning the error: `Invalid registration operator name`
- This was misleading because the registration ID itself could be valid, but the actual issue was that it was already in use.
- This PR fixes the operator creation flow so duplicate registration IDs return a dedicated and clearer error message.

**Current Behaviour:-**

- If the registration ID is empty, the API continues to return the existing invalid registration ID error.
- If the registration ID already exists, the API now returns: `An operator with this registration-ID already exists.`

 **Test Screenshot:-**
- If the registration ID already exists:-  
<img width="1364" height="366" alt="image" src="https://github.com/user-attachments/assets/7a1dc216-6616-4ed4-a436-e1c53492fe2f" />