### PR TITLE
added management role api endpoints

### DIFF
--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -3164,6 +3164,128 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
+  /managementRole/{id}:
+    get:
+      tags:
+        - Management Roles
+      operationId: getManagementRole
+      summary: Retrieve a specific management role.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: query
+          name: expandInUse
+          schema:
+            type: boolean
+          required: false
+      responses:
+        200:
+          description: Successful retrieval of a management role
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ManagementRole'
+                  - $ref: '#/components/schemas/ExpandedUseEntryMapList'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags:
+        - Management Roles
+      operationId: createManagementRole
+      summary: Create a specific management role.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      requestBody:
+        description: Information used to create the new management role
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagementRole'
+      responses:
+        200:
+          description: Successful creation of a management role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementRole'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+        - Management Roles
+      operationId: modifyManagementRole
+      summary: Modify a specific management role.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          required: true
+      requestBody:
+        description: Information used to modify the management role.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagementRole'
+      responses:
+        200:
+          description: Successful modification of a management role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagementRole'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Management Roles
+      operationId: deleteManagementRole
+      summary: Delete a specific management role.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - in: query
+          name: force
+          schema:
+            type: boolean
+          required: false
+      responses:
+        204:
+          $ref: '#/components/responses/Success'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+
   /configuration:
     get:
       tags:

--- a/src/RESTAPI/RESTAPI_managementRole_handler.h
+++ b/src/RESTAPI/RESTAPI_managementRole_handler.h
@@ -19,7 +19,7 @@ namespace OpenWifi {
 													  Poco::Net::HTTPRequest::HTTP_DELETE,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
 							 Server, TransactionId, Internal) {}
-		static auto PathName() { return std::list<std::string>{"/api/v1/managementRole/{uuid}"}; };
+		static auto PathName() { return std::list<std::string>{"/api/v1/managementRole/{id}"}; };
 
 	  private:
 		ManagementRoleDB &DB_ = StorageService()->RolesDB();

--- a/src/RESTAPI/RESTAPI_routers.cpp
+++ b/src/RESTAPI/RESTAPI_routers.cpp
@@ -16,6 +16,7 @@
 #include "RESTAPI/RESTAPI_location_list_handler.h"
 #include "RESTAPI/RESTAPI_managementPolicy_handler.h"
 #include "RESTAPI/RESTAPI_managementPolicy_list_handler.h"
+#include "RESTAPI/RESTAPI_managementRole_handler.h"
 #include "RESTAPI/RESTAPI_managementRole_list_handler.h"
 #include "RESTAPI/RESTAPI_map_handler.h"
 #include "RESTAPI/RESTAPI_map_list_handler.h"
@@ -60,7 +61,8 @@ namespace OpenWifi {
 			RESTAPI_location_list_handler, RESTAPI_venue_handler, RESTAPI_venue_list_handler,
 			RESTAPI_inventory_handler, RESTAPI_inventory_list_handler,
 			RESTAPI_managementPolicy_handler, RESTAPI_managementPolicy_list_handler,
-			RESTAPI_managementRole_list_handler, RESTAPI_configurations_handler,
+			RESTAPI_managementRole_handler, RESTAPI_managementRole_list_handler,
+			RESTAPI_configurations_handler,
 			RESTAPI_configurations_list_handler, RESTAPI_map_handler, RESTAPI_map_list_handler,
 			RESTAPI_webSocketServer, RESTAPI_iptocountry_handler, RESTAPI_subscriber_handler,
 			RESTAPI_variables_handler, RESTAPI_variables_list_handler, RESTAPI_sub_devices_handler,
@@ -87,7 +89,8 @@ namespace OpenWifi {
 			RESTAPI_location_list_handler, RESTAPI_venue_handler, RESTAPI_venue_list_handler,
 			RESTAPI_inventory_handler, RESTAPI_inventory_list_handler,
 			RESTAPI_managementPolicy_handler, RESTAPI_managementPolicy_list_handler,
-			RESTAPI_managementRole_list_handler, RESTAPI_configurations_handler,
+			RESTAPI_managementRole_handler, RESTAPI_managementRole_list_handler,
+			RESTAPI_configurations_handler,
 			RESTAPI_configurations_list_handler, RESTAPI_map_handler, RESTAPI_map_list_handler,
 			RESTAPI_webSocketServer, RESTAPI_iptocountry_handler, RESTAPI_subscriber_handler,
 			RESTAPI_variables_handler, RESTAPI_variables_list_handler, RESTAPI_sub_devices_handler,


### PR DESCRIPTION
# Expose Management Role REST API and OpenAPI definitions

## Summary

This PR exposes the existing Management Role detail handler in OWPROV and updates the OpenAPI contract with Management Role endpoint documentation.

The Management Role handler implementation already existed, but it was not registered in the external/internal REST routers. This PR wires the handler into the router so Management Role detail CRUD endpoints can be reached through the API.

## Changes

### Router registration

Updated:

- `src/RESTAPI/RESTAPI_routers.cpp`

Changes include:

- Added `RESTAPI_managementRole_handler.h`
- Registered `RESTAPI_managementRole_handler` in `RESTAPI_ExtRouter`
- Registered `RESTAPI_managementRole_handler` in `RESTAPI_IntRouter`

This exposes the existing detail handler alongside the existing list handler.

### OpenAPI updates

Updated:

- `openapi/owprov.yaml`

## Endpoints covered

This PR exposes/documents Management Role APIs for:

```http
GET    /api/v1/managementRole
GET    /api/v1/managementRole/{id}
POST   /api/v1/managementRole/{id}
PUT    /api/v1/managementRole/{id}
DELETE /api/v1/managementRole/{id}