### PR TITLE
Add IANA timezone support in Location, fix inUse tracking in db, and migrate createObjects to body

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir -p "$OWPROV_ROOT" "$OWPROV_CONFIG" && \
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     librdkafka++1 gosu gettext ca-certificates bash jq curl wget \
-    libmariadb-dev-compat libpq5 postgresql-client libfmt7
+    libmariadb-dev-compat libpq5 postgresql-client libfmt7 tzdata
 
 COPY readiness_check /readiness_check
 COPY test_scripts/curl/cli /cli

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -375,7 +375,7 @@ components:
         - type: object
           properties:
             createObjects:
-              $ref: '#/components/schemas/CreateObjects'
+              $ref: '#/components/schemas/VenueCreateObjects'
 
     VenueUpdateRequest:
       allOf:
@@ -383,34 +383,39 @@ components:
         - type: object
           properties:
             createObjects:
-              $ref: '#/components/schemas/CreateObjects'
+              $ref: '#/components/schemas/VenueCreateObjects'
 
-    CreateObjects:
+    VenueCreateObjects:
       type: object
-      description: Inline objects to create and automatically link during parent object creation or modification
+      description: Inline location objects to create and automatically link during Venue creation or modification
       properties:
         objects:
           type: array
           items:
-            oneOf:
-              - type: object
-                properties:
-                  location:
-                    $ref: '#/components/schemas/Location'
-                required:
-                  - location
-              - type: object
-                properties:
-                  contact:
-                    $ref: '#/components/schemas/Contact'
-                required:
-                  - contact
-              - type: object
-                properties:
-                  configuration:
-                    $ref: '#/components/schemas/DeviceConfiguration'
-                required:
-                  - configuration
+            type: object
+            additionalProperties: false
+            properties:
+              location:
+                $ref: '#/components/schemas/Location'
+            required:
+              - location
+      required:
+        - objects
+
+    InventoryCreateObjects:
+      type: object
+      description: Inline configuration objects to create and automatically link during Inventory creation or modification
+      properties:
+        objects:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              configuration:
+                $ref: '#/components/schemas/DeviceConfiguration'
+            required:
+              - configuration
       required:
         - objects
 
@@ -915,7 +920,7 @@ components:
         - type: object
           properties:
             createObjects:
-              $ref: '#/components/schemas/CreateObjects'
+              $ref: '#/components/schemas/InventoryCreateObjects'
 
     InventoryUpdateRequest:
       allOf:
@@ -923,7 +928,7 @@ components:
         - type: object
           properties:
             createObjects:
-              $ref: '#/components/schemas/CreateObjects'
+              $ref: '#/components/schemas/InventoryCreateObjects'
 
     VenueDeviceList:
       type: object

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -391,6 +391,8 @@ components:
       properties:
         objects:
           type: array
+          minItems: 1
+          maxItems: 1
           items:
             type: object
             additionalProperties: false
@@ -408,6 +410,8 @@ components:
       properties:
         objects:
           type: array
+          minItems: 1
+          maxItems: 1
           items:
             type: object
             additionalProperties: false

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -398,7 +398,7 @@ components:
             additionalProperties: false
             properties:
               location:
-                $ref: '#/components/schemas/Location'
+                $ref: '#/components/schemas/LocationCreateRequest'
             required:
               - location
       required:
@@ -533,6 +533,13 @@ components:
           type: string
           description: IANA Timezone identifier string
           example: Asia/Kolkata
+
+    LocationCreateRequest:
+      allOf:
+        - $ref: '#/components/schemas/Location'
+        - type: object
+          required:
+            - timezone
 
     LocationList:
       type: object
@@ -2223,7 +2230,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Location'
+              $ref: '#/components/schemas/LocationCreateRequest'
       responses:
         200:
           $ref: '#/components/schemas/Location'

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -392,14 +392,27 @@ components:
         objects:
           type: array
           items:
-            type: object
-            properties:
-              location:
-                $ref: '#/components/schemas/Location'
-              contact:
-                $ref: '#/components/schemas/Contact'
-              configuration:
-                $ref: '#/components/schemas/DeviceConfiguration'
+            oneOf:
+              - type: object
+                properties:
+                  location:
+                    $ref: '#/components/schemas/Location'
+                required:
+                  - location
+              - type: object
+                properties:
+                  contact:
+                    $ref: '#/components/schemas/Contact'
+                required:
+                  - contact
+              - type: object
+                properties:
+                  configuration:
+                    $ref: '#/components/schemas/DeviceConfiguration'
+                required:
+                  - configuration
+      required:
+        - objects
 
     VenueList:
       type: object

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -368,6 +368,22 @@ components:
           items:
             type: string
             format: uuid
+        createObjects:
+          $ref: '#/components/schemas/CreateObjects'
+
+    CreateObjects:
+      type: object
+      description: Inline objects to create and automatically link during parent object creation or modification
+      properties:
+        objects:
+          type: array
+          items:
+            type: object
+            properties:
+              location:
+                $ref: '#/components/schemas/Location'
+              configuration:
+                $ref: '#/components/schemas/DeviceConfiguration'
 
     VenueList:
       type: object
@@ -863,6 +879,8 @@ components:
           enum:
             - AP
             - SWITCH
+        createObjects:
+          $ref: '#/components/schemas/CreateObjects'
 
     VenueDeviceList:
       type: object
@@ -2675,24 +2693,6 @@ paths:
             type: string
             format: uuid
           required: true
-        - in: query
-          name: createObjects
-          schema:
-            type: object
-            properties:
-              objects:
-                type: array
-                items:
-                  oneOf:
-                    - type: object
-                      properties:
-                        location:
-                          $ref: '#/components/schemas/Location'
-                    - type: object
-                      properties:
-                        contact:
-                          $ref: '#/components/schemas/Contact'
-          required: false
       requestBody:
         description: Information used to create the new venue
         content:

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -396,6 +396,8 @@ components:
             properties:
               location:
                 $ref: '#/components/schemas/Location'
+              contact:
+                $ref: '#/components/schemas/Contact'
               configuration:
                 $ref: '#/components/schemas/DeviceConfiguration'
 

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -475,6 +475,10 @@ components:
           format: uuid
         geoCode:
           type: string
+        timezone:
+          type: string
+          description: IANA Timezone identifier string
+          example: Asia/Kolkata
 
     LocationList:
       type: object

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -368,8 +368,22 @@ components:
           items:
             type: string
             format: uuid
-        createObjects:
-          $ref: '#/components/schemas/CreateObjects'
+
+    VenueCreateRequest:
+      allOf:
+        - $ref: '#/components/schemas/Venue'
+        - type: object
+          properties:
+            createObjects:
+              $ref: '#/components/schemas/CreateObjects'
+
+    VenueUpdateRequest:
+      allOf:
+        - $ref: '#/components/schemas/Venue'
+        - type: object
+          properties:
+            createObjects:
+              $ref: '#/components/schemas/CreateObjects'
 
     CreateObjects:
       type: object
@@ -879,8 +893,22 @@ components:
           enum:
             - AP
             - SWITCH
-        createObjects:
-          $ref: '#/components/schemas/CreateObjects'
+
+    InventoryCreateRequest:
+      allOf:
+        - $ref: '#/components/schemas/InventoryTag'
+        - type: object
+          properties:
+            createObjects:
+              $ref: '#/components/schemas/CreateObjects'
+
+    InventoryUpdateRequest:
+      allOf:
+        - $ref: '#/components/schemas/InventoryTag'
+        - type: object
+          properties:
+            createObjects:
+              $ref: '#/components/schemas/CreateObjects'
 
     VenueDeviceList:
       type: object
@@ -2417,7 +2445,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InventoryTag'
+              $ref: '#/components/schemas/InventoryCreateRequest'
       responses:
         200:
           $ref: '#/components/schemas/InventoryTag'
@@ -2451,7 +2479,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InventoryTag'
+              $ref: '#/components/schemas/InventoryUpdateRequest'
 
       responses:
         200:
@@ -2698,7 +2726,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Venue'
+              $ref: '#/components/schemas/VenueCreateRequest'
 
       responses:
         200:
@@ -2759,7 +2787,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Venue'
+              $ref: '#/components/schemas/VenueUpdateRequest'
 
       responses:
         200:

--- a/openapi/owprov.yaml
+++ b/openapi/owprov.yaml
@@ -2681,6 +2681,13 @@ paths:
             example:
               - this is the shortname of the RRM vendor
           required: false
+        - in: query
+          description: filter venues by subscriber ID
+          name: subscriberId
+          schema:
+            type: string
+            format: uuid
+          required: false
       responses:
         200:
           description: Return a list of venues.

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -506,82 +506,89 @@ namespace OpenWifi {
 
 	template <typename Type>
 	std::map<std::string, std::string> CreateObjects(Type &NewObject, RESTAPIHandler &R,
+													 const Poco::JSON::Object::Ptr &RawObject,
 													 std::vector<std::string> &Errors) {
 		std::map<std::string, std::string> Result;
 
-		auto createObjects = R.GetParameter("createObjects", "");
-		if (!createObjects.empty()) {
-			Poco::JSON::Parser P;
-			auto Objects = P.parse(createObjects).extract<Poco::JSON::Object::Ptr>();
-			if (Objects->isArray("objects")) {
-				auto ObjectsArray = Objects->getArray("objects");
-				for (const auto &i : *ObjectsArray) {
-					auto Object = i.extract<Poco::JSON::Object::Ptr>();
-					if (Object->has("location")) {
-						auto LocationDetails =
-							Object->get("location").extract<Poco::JSON::Object::Ptr>();
-						ProvObjects::Location LC;
-						if (LC.from_json(LocationDetails)) {
-							if constexpr (std::is_same_v<Type, ProvObjects::Venue>) {
-								std::string ParentEntity = FindParentEntity(NewObject);
-								ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, LC.info);
-								LC.entity = ParentEntity;
-								if (StorageService()->LocationDB().CreateRecord(LC)) {
-									NewObject.location = LC.info.id;
-									AddMembership(StorageService()->EntityDB(),
-												  &ProvObjects::Entity::locations, ParentEntity,
-												  LC.info.id);
-									Result["location"] = LC.info.id;
-								}
+		// Reject createObjects passed as a URL query parameter
+		std::string queryParamValue;
+		if (R.HasParameter("createObjects", queryParamValue)) {
+			Errors.push_back("createObjects must be provided in the request body, not as a URL query parameter");
+			return Result;
+		}
+
+		// Read createObjects from the JSON request body
+		if (RawObject && RawObject->has("createObjects")) {
+			if (!RawObject->isObject("createObjects")) {
+				Errors.push_back("Invalid JSON document: createObjects must be a JSON object");
+				return Result;
+			}
+			auto Objects = RawObject->getObject("createObjects");
+			if (!Objects->isArray("objects")) {
+				Errors.push_back("Invalid JSON document: createObjects must contain an objects array");
+				return Result;
+			}
+			auto ObjectsArray = Objects->getArray("objects");
+			for (const auto &i : *ObjectsArray) {
+				auto Object = i.extract<Poco::JSON::Object::Ptr>();
+				if (Object->has("location")) {
+					auto LocationDetails = Object->get("location").extract<Poco::JSON::Object::Ptr>();
+					ProvObjects::Location LC;
+					if (LC.from_json(LocationDetails)) {
+						if constexpr (std::is_same_v<Type, ProvObjects::Venue>) {
+							std::string ParentEntity = FindParentEntity(NewObject);
+							ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, LC.info);
+							LC.entity = ParentEntity;
+							if (StorageService()->LocationDB().CreateRecord(LC)) {
+								NewObject.location = LC.info.id;
+								AddMembership(StorageService()->EntityDB(), &ProvObjects::Entity::locations, ParentEntity, LC.info.id);
+								Result["location"] = LC.info.id;
 							}
-							if constexpr (std::is_same_v<Type, ProvObjects::Operator>) {
-								std::string ParentEntity = FindParentEntity(NewObject);
-								ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, LC.info);
-								LC.entity = ParentEntity;
-								if (StorageService()->LocationDB().CreateRecord(LC)) {
-									NewObject.location = LC.info.id;
-									AddMembership(StorageService()->EntityDB(),
-												  &ProvObjects::Entity::locations, ParentEntity,
-												  LC.info.id);
-									Result["location"] = LC.info.id;
-								}
+						}
+						if constexpr (std::is_same_v<Type, ProvObjects::Operator>) {
+							std::string ParentEntity = FindParentEntity(NewObject);
+							ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, LC.info);
+							LC.entity = ParentEntity;
+							if (StorageService()->LocationDB().CreateRecord(LC)) {
+								NewObject.location = LC.info.id;
+								AddMembership(StorageService()->EntityDB(), &ProvObjects::Entity::locations, ParentEntity, LC.info.id);
+								Result["location"] = LC.info.id;
 							}
-						} else {
-							Errors.push_back("Invalid JSON document");
-							break;
 						}
-					} else if (Object->has("contact")) {
-						auto ContactDetails =
-							Object->get("contact").extract<Poco::JSON::Object::Ptr>();
-						ProvObjects::Contact CC;
-						if (CC.from_json(ContactDetails)) {
-							std::cout << "contact decoded: " << CC.info.name << std::endl;
-						} else {
-							std::cout << "contact not decoded." << std::endl;
-						}
-					} else if (Object->has("configuration")) {
-						auto ConfigurationDetails =
-							Object->get("configuration")
-								.template extract<Poco::JSON::Object::Ptr>();
-						ProvObjects::DeviceConfiguration DC;
-						if (DC.from_json(ConfigurationDetails)) {
-							if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
-								auto ValidationType =
-									ConfigurationValidator::GetType(NewObject.platform);
-								if (!ValidateConfigBlock(ValidationType, DC, Errors)) {
-									break;
-								}
-								ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, DC.info);
-								if (StorageService()->ConfigurationDB().CreateRecord(DC)) {
-									NewObject.deviceConfiguration = DC.info.id;
-									Result["configuration"] = DC.info.id;
-								}
-							}
-						} else {
-							Errors.push_back("Invalid JSON document");
-							break;
-						}
+					} else {
+						Errors.push_back("Invalid JSON document");
+						break;
 					}
+				} else if (Object->has("contact")) {
+					auto ContactDetails = Object->get("contact").extract<Poco::JSON::Object::Ptr>();
+					ProvObjects::Contact CC;
+					if (CC.from_json(ContactDetails)) {
+						std::cout << "contact decoded: " << CC.info.name << std::endl;
+					} else {
+						std::cout << "contact not decoded." << std::endl;
+					}
+				} else if (Object->has("configuration")) {
+					auto ConfigurationDetails = Object->get("configuration").template extract<Poco::JSON::Object::Ptr>();
+					ProvObjects::DeviceConfiguration DC;
+					if (DC.from_json(ConfigurationDetails)) {
+						if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
+							auto ValidationType = ConfigurationValidator::GetType(NewObject.platform);
+							if (!ValidateConfigBlock(ValidationType, DC, Errors)) {
+								break;
+							}
+							ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, DC.info);
+							if (StorageService()->ConfigurationDB().CreateRecord(DC)) {
+								NewObject.deviceConfiguration = DC.info.id;
+								Result["configuration"] = DC.info.id;
+							}
+						}
+					} else {
+						Errors.push_back("Invalid JSON document");
+						break;
+					}
+				} else {
+					Errors.push_back("Invalid JSON document");
+					break;
 				}
 			}
 		}

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -530,6 +530,10 @@ namespace OpenWifi {
 				return Result;
 			}
 			auto ObjectsArray = Objects->getArray("objects");
+			if (ObjectsArray->size() != 1) {
+				Errors.push_back("Invalid JSON document: createObjects.objects array must contain exactly one item");
+				return Result;
+			}
 
 			// Phase 1: Pre-validation scan
 			for (std::size_t i = 0; i < ObjectsArray->size(); ++i) {

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -584,18 +584,16 @@ namespace OpenWifi {
 							}
 						}
 					}
-					if (LocationObj->has("timezone")) {
-						if (!LocationObj->get("timezone").isString()) {
-							Errors.push_back("Invalid timezone identifier in createObjects.location");
-							return Result;
-						}
-						auto Timezone = Poco::trim(LocationObj->get("timezone").toString());
-						if (!Utils::ValidTimeZone(Timezone)) {
-							Errors.push_back("Invalid timezone identifier in createObjects.location");
-							return Result;
-						}
-						LocationObj->set("timezone", Timezone);
+					if (!LocationObj->has("timezone") || !LocationObj->get("timezone").isString()) {
+						Errors.push_back("Invalid timezone identifier in createObjects.location");
+						return Result;
 					}
+					auto Timezone = Poco::trim(LocationObj->get("timezone").toString());
+					if (!Utils::ValidTimeZone(Timezone)) {
+						Errors.push_back("Invalid timezone identifier in createObjects.location");
+						return Result;
+					}
+					LocationObj->set("timezone", Timezone);
 				} else if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
 					if (!Object->has("configuration")) {
 						Errors.push_back("Invalid JSON document: item in createObjects.objects must contain configuration");

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -627,6 +627,9 @@ namespace OpenWifi {
 								NewObject.location = LC.info.id;
 								AddMembership(StorageService()->EntityDB(), &ProvObjects::Entity::locations, ParentEntity, LC.info.id);
 								Result["location"] = LC.info.id;
+							} else {
+								Errors.push_back("Could not create inline location");
+								return Result;
 							}
 						} else if constexpr (std::is_same_v<Type, ProvObjects::Operator>) {
 							std::string ParentEntity = FindParentEntity(NewObject);
@@ -636,6 +639,9 @@ namespace OpenWifi {
 								NewObject.location = LC.info.id;
 								AddMembership(StorageService()->EntityDB(), &ProvObjects::Entity::locations, ParentEntity, LC.info.id);
 								Result["location"] = LC.info.id;
+							} else {
+								Errors.push_back("Could not create inline location");
+								return Result;
 							}
 						}
 					} else {
@@ -663,6 +669,9 @@ namespace OpenWifi {
 							if (StorageService()->ConfigurationDB().CreateRecord(DC)) {
 								NewObject.deviceConfiguration = DC.info.id;
 								Result["configuration"] = DC.info.id;
+							} else {
+								Errors.push_back("Could not create inline configuration");
+								return Result;
 							}
 						}
 					} else {

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -10,6 +10,7 @@
 #include "RESTObjects/RESTAPI_ProvObjects.h"
 #include "StorageService.h"
 #include "framework/ConfigurationValidator.h"
+#include "framework/utils.h"
 #include "libs/croncpp.h"
 #include "sdks/SDK_sec.h"
 
@@ -538,14 +539,17 @@ namespace OpenWifi {
 				}
 				auto Object = ObjectsArray->getObject(i);
 
-				if (Object->has("contact")) {
-					if (!Object->isObject("contact")) {
-						Errors.push_back("Invalid JSON document: contact in createObjects must be a JSON object");
-						return Result;
-					}
+				if ((Object->has("location") + Object->has("configuration") + Object->has("contact")) != 1) {
+					Errors.push_back("Invalid JSON document: item in createObjects.objects must contain exactly one of location, configuration, or contact");
+					return Result;
 				}
 
-				if (Object->has("location")) {
+				if constexpr (std::is_same_v<Type, ProvObjects::Venue> || std::is_same_v<Type, ProvObjects::Operator>) {
+					if (!Object->has("location")) {
+						Errors.push_back("Invalid JSON document: item in createObjects.objects must contain location");
+						return Result;
+					}
+
 					if (!Object->isObject("location")) {
 						Errors.push_back("Invalid JSON document: location in createObjects must be a JSON object");
 						return Result;
@@ -567,17 +571,18 @@ namespace OpenWifi {
 						}
 						LocationObj->set("timezone", Timezone);
 					}
-				}
+				} else if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
+					if (!Object->has("configuration")) {
+						Errors.push_back("Invalid JSON document: item in createObjects.objects must contain configuration");
+						return Result;
+					}
 
-				if (Object->has("configuration")) {
 					if (!Object->isObject("configuration")) {
 						Errors.push_back("Invalid JSON document: configuration in createObjects must be a JSON object");
 						return Result;
 					}
-				}
-
-				if (!Object->has("location") && !Object->has("configuration") && !Object->has("contact")) {
-					Errors.push_back("Invalid JSON document: item in createObjects.objects must contain location or configuration or contact");
+				} else {
+					Errors.push_back("Unsupported object type for inline creation");
 					return Result;
 				}
 			}

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -606,6 +606,10 @@ namespace OpenWifi {
 						Errors.push_back("Invalid JSON document: configuration in createObjects must be a JSON object");
 						return Result;
 					}
+					if (RawObject->has("deviceConfiguration")) {
+						Errors.push_back("Cannot specify both deviceConfiguration and createObjects.configuration");
+						return Result;
+					}
 				} else {
 					Errors.push_back("Unsupported object type for inline creation");
 					return Result;

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -569,9 +569,19 @@ namespace OpenWifi {
 							return Result;
 						}
 						std::string locationName = Poco::trim(LocationObj->get("name").toString());
-						if (!locationName.empty() && StorageService()->LocationDB().Exists("name", locationName)) {
-							Errors.push_back("Location name already exists");
-							return Result;
+						if constexpr (std::is_same_v<Type, ProvObjects::Venue>) {
+							if (!locationName.empty() && !NewObject.location.empty()) {
+								ProvObjects::Location ExistingLC;
+								if (StorageService()->LocationDB().GetRecord("id", NewObject.location, ExistingLC)) {
+									if (ExistingLC.info.name == locationName) {
+										Errors.push_back("Location name already exists");
+										return Result;
+									}
+								} else {
+									Errors.push_back("Could not load location record");
+									return Result;
+								}
+							}
 						}
 					}
 					if (LocationObj->has("timezone")) {

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -529,10 +529,64 @@ namespace OpenWifi {
 				return Result;
 			}
 			auto ObjectsArray = Objects->getArray("objects");
-			for (const auto &i : *ObjectsArray) {
-				auto Object = i.extract<Poco::JSON::Object::Ptr>();
+
+			// Phase 1: Pre-validation scan
+			for (std::size_t i = 0; i < ObjectsArray->size(); ++i) {
+				if (!ObjectsArray->isObject(i)) {
+					Errors.push_back("Invalid JSON document: items in createObjects.objects must be JSON objects");
+					return Result;
+				}
+				auto Object = ObjectsArray->getObject(i);
+
+				if (Object->has("contact")) {
+					if (!Object->isObject("contact")) {
+						Errors.push_back("Invalid JSON document: contact in createObjects must be a JSON object");
+						return Result;
+					}
+				}
+
 				if (Object->has("location")) {
-					auto LocationDetails = Object->get("location").extract<Poco::JSON::Object::Ptr>();
+					if (!Object->isObject("location")) {
+						Errors.push_back("Invalid JSON document: location in createObjects must be a JSON object");
+						return Result;
+					}
+					if (RawObject->has("location")) {
+						Errors.push_back("Cannot specify both location and createObjects.location");
+						return Result;
+					}
+					auto LocationObj = Object->getObject("location");
+					if (LocationObj->has("timezone")) {
+						if (!LocationObj->get("timezone").isString()) {
+							Errors.push_back("Invalid timezone identifier in createObjects.location");
+							return Result;
+						}
+						auto Timezone = Poco::trim(LocationObj->get("timezone").toString());
+						if (!Utils::ValidTimeZone(Timezone)) {
+							Errors.push_back("Invalid timezone identifier in createObjects.location");
+							return Result;
+						}
+						LocationObj->set("timezone", Timezone);
+					}
+				}
+
+				if (Object->has("configuration")) {
+					if (!Object->isObject("configuration")) {
+						Errors.push_back("Invalid JSON document: configuration in createObjects must be a JSON object");
+						return Result;
+					}
+				}
+
+				if (!Object->has("location") && !Object->has("configuration") && !Object->has("contact")) {
+					Errors.push_back("Invalid JSON document: item in createObjects.objects must contain location or configuration or contact");
+					return Result;
+				}
+			}
+
+			// Phase 2: Object Creation & Persistence
+			for (std::size_t i = 0; i < ObjectsArray->size(); ++i) {
+				auto Object = ObjectsArray->getObject(i);
+				if (Object->has("location")) {
+					auto LocationDetails = Object->getObject("location");
 					ProvObjects::Location LC;
 					if (LC.from_json(LocationDetails)) {
 						if constexpr (std::is_same_v<Type, ProvObjects::Venue>) {
@@ -544,8 +598,7 @@ namespace OpenWifi {
 								AddMembership(StorageService()->EntityDB(), &ProvObjects::Entity::locations, ParentEntity, LC.info.id);
 								Result["location"] = LC.info.id;
 							}
-						}
-						if constexpr (std::is_same_v<Type, ProvObjects::Operator>) {
+						} else if constexpr (std::is_same_v<Type, ProvObjects::Operator>) {
 							std::string ParentEntity = FindParentEntity(NewObject);
 							ProvObjects::CreateObjectInfo(R.UserInfo_.userinfo, LC.info);
 							LC.entity = ParentEntity;
@@ -560,7 +613,7 @@ namespace OpenWifi {
 						break;
 					}
 				} else if (Object->has("contact")) {
-					auto ContactDetails = Object->get("contact").extract<Poco::JSON::Object::Ptr>();
+					auto ContactDetails = Object->getObject("contact");
 					ProvObjects::Contact CC;
 					if (CC.from_json(ContactDetails)) {
 						std::cout << "contact decoded: " << CC.info.name << std::endl;
@@ -568,7 +621,7 @@ namespace OpenWifi {
 						std::cout << "contact not decoded." << std::endl;
 					}
 				} else if (Object->has("configuration")) {
-					auto ConfigurationDetails = Object->get("configuration").template extract<Poco::JSON::Object::Ptr>();
+					auto ConfigurationDetails = Object->getObject("configuration");
 					ProvObjects::DeviceConfiguration DC;
 					if (DC.from_json(ConfigurationDetails)) {
 						if constexpr (std::is_same_v<Type, ProvObjects::InventoryTag>) {
@@ -586,9 +639,6 @@ namespace OpenWifi {
 						Errors.push_back("Invalid JSON document");
 						break;
 					}
-				} else {
-					Errors.push_back("Invalid JSON document");
-					break;
 				}
 			}
 		}

--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -563,6 +563,17 @@ namespace OpenWifi {
 						return Result;
 					}
 					auto LocationObj = Object->getObject("location");
+					if (LocationObj->has("name")) {
+						if (!LocationObj->get("name").isString()) {
+							Errors.push_back("Invalid name in createObjects.location");
+							return Result;
+						}
+						std::string locationName = Poco::trim(LocationObj->get("name").toString());
+						if (!locationName.empty() && StorageService()->LocationDB().Exists("name", locationName)) {
+							Errors.push_back("Location name already exists");
+							return Result;
+						}
+					}
 					if (LocationObj->has("timezone")) {
 						if (!LocationObj->get("timezone").isString()) {
 							Errors.push_back("Invalid timezone identifier in createObjects.location");

--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -283,7 +283,7 @@ namespace OpenWifi {
 		}
 
 		std::vector<std::string> Errors;
-		auto ObjectsCreated = CreateObjects(NewObject, *this, Errors);
+		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
@@ -461,7 +461,7 @@ namespace OpenWifi {
 		}
 
 		std::vector<std::string> Errors;
-		auto ObjectsCreated = CreateObjects(NewObject, *this, Errors);
+		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
@@ -469,7 +469,7 @@ namespace OpenWifi {
 		if (!ObjectsCreated.empty()) {
 			auto it = ObjectsCreated.find("configuration");
 			if (it != ObjectsCreated.end()) {
-				FromConfiguration = "";
+				FromConfiguration = Existing.deviceConfiguration;
 				ToConfiguration = it->second;
 				Existing.deviceConfiguration = ToConfiguration;
 			}

--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -290,7 +290,7 @@ namespace OpenWifi {
 					return BadRequest(RESTAPI::Errors::InvalidTimezone);
 				}
 			}
-			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
+			return BadRequest(RESTAPI::Errors::InvalidCreateObjectsRequest, Errors[0]);
 		}
 
 		if (DB_.CreateRecord(NewObject)) {
@@ -473,7 +473,7 @@ namespace OpenWifi {
 					return BadRequest(RESTAPI::Errors::InvalidTimezone);
 				}
 			}
-			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
+			return BadRequest(RESTAPI::Errors::InvalidCreateObjectsRequest, Errors[0]);
 		}
 
 		if (!ObjectsCreated.empty()) {

--- a/src/RESTAPI/RESTAPI_inventory_handler.cpp
+++ b/src/RESTAPI/RESTAPI_inventory_handler.cpp
@@ -285,6 +285,11 @@ namespace OpenWifi {
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
+			for (const auto &err : Errors) {
+				if (err.find("timezone") != std::string::npos || err.find("Timezone") != std::string::npos) {
+					return BadRequest(RESTAPI::Errors::InvalidTimezone);
+				}
+			}
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 
@@ -463,6 +468,11 @@ namespace OpenWifi {
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
+			for (const auto &err : Errors) {
+				if (err.find("timezone") != std::string::npos || err.find("Timezone") != std::string::npos) {
+					return BadRequest(RESTAPI::Errors::InvalidTimezone);
+				}
+			}
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 

--- a/src/RESTAPI/RESTAPI_location_handler.cpp
+++ b/src/RESTAPI/RESTAPI_location_handler.cpp
@@ -148,6 +148,7 @@ namespace OpenWifi {
 		AssignIfPresent(RawObject, "postal", Existing.postal);
 		AssignIfPresent(RawObject, "country", Existing.country);
 		AssignIfPresent(RawObject, "geoCode", Existing.geoCode);
+		AssignIfPresent(RawObject, "timezone", Existing.timezone);
 		if (RawObject->has("addressLines"))
 			Existing.addressLines = NewObject.addressLines;
 		if (RawObject->has("phones"))

--- a/src/RESTAPI/RESTAPI_location_handler.cpp
+++ b/src/RESTAPI/RESTAPI_location_handler.cpp
@@ -78,9 +78,23 @@ namespace OpenWifi {
 		}
 
 		const auto &Obj = ParsedBody_;
+		if (Obj->has("timezone")) {
+			if (!Obj->get("timezone").isString()) {
+				return BadRequest(RESTAPI::Errors::InvalidTimezone);
+			}
+			auto Timezone = Poco::trim(Obj->get("timezone").toString());
+			if (!Utils::ValidTimeZone(Timezone)) {
+				return BadRequest(RESTAPI::Errors::InvalidTimezone);
+			}
+		}
+
 		ProvObjects::Location NewObject;
 		if (!NewObject.from_json(Obj)) {
 			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		if (Obj->has("timezone")) {
+			NewObject.timezone = Poco::trim(Obj->get("timezone").toString());
 		}
 
 		if (!ProvObjects::CreateObjectInfo(Obj, UserInfo_.userinfo, NewObject.info)) {
@@ -123,9 +137,23 @@ namespace OpenWifi {
 		}
 
 		const auto &RawObject = ParsedBody_;
+		if (RawObject->has("timezone")) {
+			if (!RawObject->get("timezone").isString()) {
+				return BadRequest(RESTAPI::Errors::InvalidTimezone);
+			}
+			auto Timezone = Poco::trim(RawObject->get("timezone").toString());
+			if (!Utils::ValidTimeZone(Timezone)) {
+				return BadRequest(RESTAPI::Errors::InvalidTimezone);
+			}
+		}
+
 		ProvObjects::Location NewObject;
 		if (!NewObject.from_json(RawObject)) {
 			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		if (RawObject->has("timezone")) {
+			Existing.timezone = Poco::trim(RawObject->get("timezone").toString());
 		}
 
 		if (!UpdateObjectInfo(RawObject, UserInfo_.userinfo, Existing.info)) {
@@ -148,7 +176,6 @@ namespace OpenWifi {
 		AssignIfPresent(RawObject, "postal", Existing.postal);
 		AssignIfPresent(RawObject, "country", Existing.country);
 		AssignIfPresent(RawObject, "geoCode", Existing.geoCode);
-		AssignIfPresent(RawObject, "timezone", Existing.timezone);
 		if (RawObject->has("addressLines"))
 			Existing.addressLines = NewObject.addressLines;
 		if (RawObject->has("phones"))

--- a/src/RESTAPI/RESTAPI_location_handler.cpp
+++ b/src/RESTAPI/RESTAPI_location_handler.cpp
@@ -78,14 +78,12 @@ namespace OpenWifi {
 		}
 
 		const auto &Obj = ParsedBody_;
-		if (Obj->has("timezone")) {
-			if (!Obj->get("timezone").isString()) {
-				return BadRequest(RESTAPI::Errors::InvalidTimezone);
-			}
-			auto Timezone = Poco::trim(Obj->get("timezone").toString());
-			if (!Utils::ValidTimeZone(Timezone)) {
-				return BadRequest(RESTAPI::Errors::InvalidTimezone);
-			}
+		if (!Obj->has("timezone") || !Obj->get("timezone").isString()) {
+			return BadRequest(RESTAPI::Errors::InvalidTimezone);
+		}
+		auto Timezone = Poco::trim(Obj->get("timezone").toString());
+		if (!Utils::ValidTimeZone(Timezone)) {
+			return BadRequest(RESTAPI::Errors::InvalidTimezone);
 		}
 
 		ProvObjects::Location NewObject;
@@ -93,9 +91,7 @@ namespace OpenWifi {
 			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
 		}
 
-		if (Obj->has("timezone")) {
-			NewObject.timezone = Poco::trim(Obj->get("timezone").toString());
-		}
+		NewObject.timezone = Timezone;
 
 		if (!ProvObjects::CreateObjectInfo(Obj, UserInfo_.userinfo, NewObject.info)) {
 			return BadRequest(RESTAPI::Errors::NameMustBeSet);

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -196,7 +196,6 @@ namespace OpenWifi {
 
 		NewObject.children.clear();
 
-		RESTAPI::Errors::msg Error = RESTAPI::Errors::SUCCESS;
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -457,7 +457,7 @@ namespace OpenWifi {
 
 		std::string MoveFromLocation, MoveToLocation;
 		if (AssignIfPresent(RawObject, "location", MoveToLocation)) {
-			if (MoveToLocation.empty() ||
+			if (!MoveToLocation.empty() &&
 				!StorageService()->LocationDB().Exists("id", MoveToLocation)) {
 				return BadRequest(RESTAPI::Errors::LocationMustExist);
 			}

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -501,6 +501,7 @@ namespace OpenWifi {
 		std::string ErrorText;
 		NewObject.parent = Existing.parent;
 		NewObject.entity = Existing.entity;
+		NewObject.location = Existing.location;
 
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -198,9 +198,9 @@ namespace OpenWifi {
 
 		RESTAPI::Errors::msg Error = RESTAPI::Errors::SUCCESS;
 		std::vector<std::string> Errors;
-		auto ObjectsCreated = CreateObjects(NewObject, *this, Errors);
-		if (Error.err_num != 0) {
-			return BadRequest(RESTAPI::Errors::InternalError);
+		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
+		if (!Errors.empty()) {
+			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 
 		if (DB_.CreateRecord(NewObject)) {
@@ -499,19 +499,17 @@ namespace OpenWifi {
 		NewObject.entity = Existing.entity;
 
 		std::vector<std::string> Errors;
-		auto ObjectsCreated = CreateObjects(NewObject, *this, Errors);
+		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 
 		if (!ObjectsCreated.empty()) {
-			if (!ObjectsCreated.empty()) {
-				auto it = ObjectsCreated.find("location");
-				if (it != ObjectsCreated.end()) {
-					MoveFromLocation = "";
-					MoveToLocation = it->second;
-					Existing.location = MoveToLocation;
-				}
+			auto it = ObjectsCreated.find("location");
+			if (it != ObjectsCreated.end()) {
+				MoveFromLocation = Existing.location;
+				MoveToLocation = it->second;
+				Existing.location = MoveToLocation;
 			}
 		}
 

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -200,6 +200,11 @@ namespace OpenWifi {
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
+			for (const auto &err : Errors) {
+				if (err.find("timezone") != std::string::npos || err.find("Timezone") != std::string::npos) {
+					return BadRequest(RESTAPI::Errors::InvalidTimezone);
+				}
+			}
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 
@@ -501,6 +506,11 @@ namespace OpenWifi {
 		std::vector<std::string> Errors;
 		auto ObjectsCreated = CreateObjects(NewObject, *this, ParsedBody_, Errors);
 		if (!Errors.empty()) {
+			for (const auto &err : Errors) {
+				if (err.find("timezone") != std::string::npos || err.find("Timezone") != std::string::npos) {
+					return BadRequest(RESTAPI::Errors::InvalidTimezone);
+				}
+			}
 			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
 		}
 

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -205,7 +205,7 @@ namespace OpenWifi {
 					return BadRequest(RESTAPI::Errors::InvalidTimezone);
 				}
 			}
-			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
+			return BadRequest(RESTAPI::Errors::InvalidCreateObjectsRequest, Errors[0]);
 		}
 
 		if (DB_.CreateRecord(NewObject)) {
@@ -511,7 +511,7 @@ namespace OpenWifi {
 					return BadRequest(RESTAPI::Errors::InvalidTimezone);
 				}
 			}
-			return BadRequest(RESTAPI::Errors::ConfigBlockInvalid);
+			return BadRequest(RESTAPI::Errors::InvalidCreateObjectsRequest, Errors[0]);
 		}
 
 		if (!ObjectsCreated.empty()) {

--- a/src/RESTAPI/RESTAPI_venue_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_list_handler.cpp
@@ -5,11 +5,15 @@
 #include "RESTAPI_venue_list_handler.h"
 #include "RESTAPI/RESTAPI_db_helpers.h"
 #include "StorageService.h"
+#include "framework/utils.h"
 
 namespace OpenWifi {
 	void RESTAPI_venue_list_handler::DoGet() {
         auto subscriberId = GetParameter("subscriberId", "");
         if (!subscriberId.empty()) {
+            if (!Utils::ValidUUID(subscriberId)) {
+                return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
+            }
             VenueDB::RecordVec Venues;
             auto Where = fmt::format(" subscriber='{}' ", ORM::Escape(subscriberId));
             DB_.GetRecords(QB_.Offset, QB_.Limit, Venues, Where, " ORDER BY name ");

--- a/src/RESTAPI/RESTAPI_venue_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_list_handler.cpp
@@ -8,6 +8,14 @@
 
 namespace OpenWifi {
 	void RESTAPI_venue_list_handler::DoGet() {
+        auto subscriberId = GetParameter("subscriberId", "");
+        if (!subscriberId.empty()) {
+            VenueDB::RecordVec Venues;
+            auto Where = fmt::format(" subscriber='{}' ", ORM::Escape(subscriberId));
+            DB_.GetRecords(QB_.Offset, QB_.Limit, Venues, Where, " ORDER BY name ");
+            return ReturnObject("venues", Venues);
+        }
+
         auto RRMvendor = GetParameter("RRMvendor","");
         if(RRMvendor.empty()) {
             return ListHandler<VenueDB>("venues", DB_, *this);

--- a/src/RESTAPI/RESTAPI_venue_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_list_handler.cpp
@@ -10,23 +10,29 @@
 namespace OpenWifi {
 	void RESTAPI_venue_list_handler::DoGet() {
         auto subscriberId = GetParameter("subscriberId", "");
-        if (!subscriberId.empty()) {
-            if (!Utils::ValidUUID(subscriberId)) {
-                return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
-            }
-            VenueDB::RecordVec Venues;
-            auto Where = fmt::format(" subscriber='{}' ", ORM::Escape(subscriberId));
-            DB_.GetRecords(QB_.Offset, QB_.Limit, Venues, Where, " ORDER BY name ");
-            return ReturnObject("venues", Venues);
+        auto RRMvendor = GetParameter("RRMvendor", "");
+
+        if (!subscriberId.empty() && !Utils::ValidUUID(subscriberId)) {
+            return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
         }
 
-        auto RRMvendor = GetParameter("RRMvendor","");
-        if(RRMvendor.empty()) {
+        if (subscriberId.empty() && RRMvendor.empty()) {
             return ListHandler<VenueDB>("venues", DB_, *this);
         }
+
+        std::string WhereClause;
+        if (!subscriberId.empty()) {
+            WhereClause += fmt::format(" subscriber='{}' ", ORM::Escape(subscriberId));
+        }
+        if (!RRMvendor.empty()) {
+            if (!WhereClause.empty()) {
+                WhereClause += " AND ";
+            }
+            WhereClause += fmt::format(" deviceRules LIKE '%{}%' ", ORM::Escape(RRMvendor));
+        }
+
         VenueDB::RecordVec Venues;
-        auto Where = fmt::format(" deviceRules LIKE '%{}%' ", RRMvendor);
-        DB_.GetRecords(QB_.Offset, QB_.Limit, Venues, Where, " ORDER BY name ");
-        return ReturnObject("venues",Venues);
+        DB_.GetRecords(QB_.Offset, QB_.Limit, Venues, WhereClause, " ORDER BY name ");
+        return ReturnObject("venues", Venues);
     }
 } // namespace OpenWifi

--- a/src/RESTObjects/RESTAPI_ProvObjects.cpp
+++ b/src/RESTObjects/RESTAPI_ProvObjects.cpp
@@ -335,6 +335,7 @@ namespace OpenWifi::ProvObjects {
 		field_to_json(Obj, "inUse", inUse);
 		field_to_json(Obj, "entity", entity);
 		field_to_json(Obj, "managementPolicy", managementPolicy);
+		field_to_json(Obj, "timezone", timezone);
 	}
 
 	bool Location::from_json(const Poco::JSON::Object::Ptr &Obj) {
@@ -355,6 +356,7 @@ namespace OpenWifi::ProvObjects {
 			field_from_json(Obj, "inUse", inUse);
 			field_from_json(Obj, "entity", entity);
 			field_from_json(Obj, "managementPolicy", managementPolicy);
+			field_from_json(Obj, "timezone", timezone);
 			return true;
 		} catch (...) {
 		}

--- a/src/RESTObjects/RESTAPI_ProvObjects.h
+++ b/src/RESTObjects/RESTAPI_ProvObjects.h
@@ -256,6 +256,7 @@ namespace OpenWifi::ProvObjects {
         Types::StringVec inUse;
         Types::UUID_t entity;
         Types::UUID_t managementPolicy;
+        std::string timezone;
 
         void to_json(Poco::JSON::Object &Obj) const;
 

--- a/src/StorageService.cpp
+++ b/src/StorageService.cpp
@@ -48,7 +48,10 @@ namespace OpenWifi {
 		EntityDB_->Create();
 		PolicyDB_->Create();
 		VenueDB_->Create();
-		LocationDB_->Create();
+		if (!LocationDB_->Create()) {
+			poco_critical(Logger(), "LocationDB initialization or migration reported failure. Halting daemon startup.");
+			return -1;
+		}
 		ContactDB_->Create();
 		InventoryDB_->Create();
 		RolesDB_->Create();

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -438,6 +438,9 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg InvalidSubscriberDeviceGroup {
 		1193, "Invalid deviceGroup. Must be either 'olg' or 'ap'."
 	};
+	static const struct msg InvalidTimezone {
+		1200, "Invalid or unknown IANA timezone identifier."
+	};
 	static const struct msg FirstSubscriberDeviceMustBeOLG {
 		1194, "First subscriber device must have deviceGroup 'olg'."
 	};

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -441,6 +441,9 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg InvalidTimezone {
 		1200, "Invalid or unknown IANA timezone identifier."
 	};
+	static const struct msg InvalidCreateObjectsRequest {
+		1201, "Invalid inline createObjects request."
+	};
 	static const struct msg FirstSubscriberDeviceMustBeOLG {
 		1194, "First subscriber device must have deviceGroup 'olg'."
 	};

--- a/src/framework/utils.cpp
+++ b/src/framework/utils.cpp
@@ -13,6 +13,8 @@
 #include <ctime>
 #include <string>
 #include <algorithm>
+#include <set>
+#include <vector>
 
 #include <resolv.h>
 
@@ -605,6 +607,65 @@ namespace OpenWifi::Utils {
 		try {
 			Poco::URI u(uri);
 			return true;
+		} catch (...) {
+		}
+		return false;
+	}
+
+	[[nodiscard]] bool ValidTimeZone(const std::string &timezone) {
+		if (timezone.empty() || timezone.size() > 100)
+			return false;
+		if (timezone.find("..") != std::string::npos || timezone.front() == '/')
+			return false;
+
+		if (timezone == "UTC" || timezone == "GMT" || timezone == "Etc/UTC" || timezone == "Etc/GMT")
+			return true;
+
+		static const std::set<std::string> BlacklistedNames{
+			"localtime", "Factory", "posixrules", "zone.tab", "zone1970.tab",
+			"zonenow.tab", "iso3166.tab", "tzdata.zi", "leapseconds", "leap-seconds.list"
+		};
+		if (BlacklistedNames.find(timezone) != BlacklistedNames.end()) {
+			return false;
+		}
+
+		std::string lowerTz = Poco::toLower(timezone);
+		if (lowerTz.rfind("posix/", 0) == 0 ||
+			lowerTz.rfind("right/", 0) == 0 ||
+			lowerTz.rfind("systemv/", 0) == 0) {
+			return false;
+		}
+
+		if (timezone.find('/') != std::string::npos) {
+			static const std::vector<std::string> ValidPrefixes{
+				"Africa/", "America/", "Antarctica/", "Arctic/", "Asia/", "Atlantic/",
+				"Australia/", "Europe/", "Indian/", "Pacific/", "Etc/", "US/", "Canada/",
+				"Brazil/", "Chile/", "Mexico/"
+			};
+
+			bool hasValidPrefix = false;
+			for (const auto &prefix : ValidPrefixes) {
+				if (timezone.rfind(prefix, 0) == 0) {
+					hasValidPrefix = true;
+					break;
+				}
+			}
+
+			if (!hasValidPrefix) {
+				return false;
+			}
+		}
+
+		try {
+			Poco::File ZoneInfoRoot("/usr/share/zoneinfo");
+			if (!ZoneInfoRoot.exists() || !ZoneInfoRoot.isDirectory()) {
+				return false;
+			}
+
+			Poco::File F("/usr/share/zoneinfo/" + timezone);
+			if (F.exists() && (F.isFile() || F.isLink())) {
+				return true;
+			}
 		} catch (...) {
 		}
 		return false;

--- a/src/framework/utils.h
+++ b/src/framework/utils.h
@@ -123,6 +123,7 @@ namespace OpenWifi::Utils {
 	[[nodiscard]] bool IsAlphaNumeric(const std::string &s);
 	[[nodiscard]] std::string SanitizeToken(const std::string &Token);
 	[[nodiscard]] bool ValidateURI(const std::string &uri);
+	[[nodiscard]] bool ValidTimeZone(const std::string &timezone);
 
 	[[nodiscard]] std::uint64_t ConvertDate(const std::string &d);
 

--- a/src/storage/storage_location.cpp
+++ b/src/storage/storage_location.cpp
@@ -47,17 +47,52 @@ namespace OpenWifi {
 	// Upgrades the locations table schema by adding the timezone column.
 	bool LocationDB::Upgrade([[maybe_unused]] uint32_t from, uint32_t &to) {
 		to = Version();
-		std::vector<std::string> Script{
-			"alter table " + TableName_ + " add column timezone text"};
 
-		for (const auto &i : Script) {
-			try {
-				auto Session = Pool_.get();
-				Session << i, Poco::Data::Keywords::now;
-			} catch (...) {
-			}
+		std::string CheckQuery;
+		if (Type_ == OpenWifi::DBType::sqlite) {
+			CheckQuery = "select count(*) from pragma_table_info('" + TableName_ + "') where lower(name) = 'timezone'";
+		} else if (Type_ == OpenWifi::DBType::pgsql) {
+			CheckQuery = "select count(*) from information_schema.columns where lower(table_name) = '" + Poco::toLower(TableName_) + "' and lower(column_name) = 'timezone' and table_schema = current_schema()";
+		} else {
+			CheckQuery = "select count(*) from information_schema.columns where lower(table_name) = '" + Poco::toLower(TableName_) + "' and lower(column_name) = 'timezone' and table_schema = database()";
 		}
-		return true;
+
+		std::size_t count = 0;
+		try {
+			auto Session = Pool_.get();
+			Session << CheckQuery, Poco::Data::Keywords::into(count), Poco::Data::Keywords::now;
+		} catch (const Poco::Exception &E) {
+			Logger().error(fmt::format("LocationDB::Upgrade schema pre-check failed on table {}: {}", TableName_, E.displayText()));
+			return false;
+		} catch (const std::exception &E) {
+			Logger().error(fmt::format("LocationDB::Upgrade schema pre-check failed on table {}: {}", TableName_, E.what()));
+			return false;
+		} catch (...) {
+			Logger().error(fmt::format("LocationDB::Upgrade schema pre-check failed on table {}: unknown exception", TableName_));
+			return false;
+		}
+
+		if (count > 0) {
+			Logger().information(fmt::format("LocationDB::Upgrade: Column 'timezone' already exists in table {}", TableName_));
+			return true;
+		}
+
+		try {
+			auto Session = Pool_.get();
+			std::string Query = "alter table " + TableName_ + " add column timezone text";
+			Session << Query, Poco::Data::Keywords::now;
+			Logger().information(fmt::format("LocationDB::Upgrade: Successfully added column 'timezone' to table {}", TableName_));
+			return true;
+		} catch (const Poco::Exception &E) {
+			Logger().error(fmt::format("LocationDB::Upgrade failed on table {}: {}", TableName_, E.displayText()));
+			return false;
+		} catch (const std::exception &E) {
+			Logger().error(fmt::format("LocationDB::Upgrade failed on table {}: {}", TableName_, E.what()));
+			return false;
+		} catch (...) {
+			Logger().error(fmt::format("LocationDB::Upgrade failed on table {}: unknown exception", TableName_));
+			return false;
+		}
 	}
 
 } // namespace OpenWifi

--- a/src/storage/storage_location.cpp
+++ b/src/storage/storage_location.cpp
@@ -34,7 +34,8 @@ namespace OpenWifi {
 										   ORM::Field{"inUse", ORM::FieldType::FT_TEXT},
 										   ORM::Field{"tags", ORM::FieldType::FT_TEXT},
 										   ORM::Field{"managementPolicy", ORM::FieldType::FT_TEXT},
-										   ORM::Field{"entity", ORM::FieldType::FT_TEXT}};
+										   ORM::Field{"entity", ORM::FieldType::FT_TEXT},
+										   ORM::Field{"timezone", ORM::FieldType::FT_TEXT}};
 
 	static ORM::IndexVec LocationDB_Indexes{
 		{std::string("location_name_index"),
@@ -42,6 +43,22 @@ namespace OpenWifi {
 
 	LocationDB::LocationDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
 		: DB(T, "locations", LocationDB_Fields, LocationDB_Indexes, P, L, "loc") {}
+
+	// Upgrades the locations table schema by adding the timezone column.
+	bool LocationDB::Upgrade([[maybe_unused]] uint32_t from, uint32_t &to) {
+		to = Version();
+		std::vector<std::string> Script{
+			"alter table " + TableName_ + " add column timezone text"};
+
+		for (const auto &i : Script) {
+			try {
+				auto Session = Pool_.get();
+				Session << i, Poco::Data::Keywords::now;
+			} catch (...) {
+			}
+		}
+		return true;
+	}
 
 } // namespace OpenWifi
 
@@ -69,6 +86,7 @@ void ORM::DB<OpenWifi::LocationDBRecordType, OpenWifi::ProvObjects::Location>::C
 	Out.info.tags = OpenWifi::RESTAPI_utils::to_taglist(In.get<17>());
 	Out.managementPolicy = In.get<18>();
 	Out.entity = In.get<19>();
+	Out.timezone = In.get<20>();
 }
 
 template <>
@@ -94,4 +112,5 @@ void ORM::DB<OpenWifi::LocationDBRecordType, OpenWifi::ProvObjects::Location>::C
 	Out.set<17>(OpenWifi::RESTAPI_utils::to_string(In.info.tags));
 	Out.set<18>(In.managementPolicy);
 	Out.set<19>(In.entity);
+	Out.set<20>(In.timezone);
 }

--- a/src/storage/storage_location.h
+++ b/src/storage/storage_location.h
@@ -15,13 +15,14 @@ namespace OpenWifi {
 	typedef Poco::Tuple<std::string, std::string, std::string, std::string, uint64_t, uint64_t,
 						std::string, std::string, std::string, std::string, std::string,
 						std::string, std::string, std::string, std::string, std::string,
-						std::string, std::string, std::string, std::string>
+						std::string, std::string, std::string, std::string, std::string>
 		LocationDBRecordType;
 
 	class LocationDB : public ORM::DB<LocationDBRecordType, ProvObjects::Location> {
 	  public:
 		LocationDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L);
 		virtual ~LocationDB(){};
+		bool Upgrade(uint32_t from, uint32_t &to) override;
 
 	  private:
 	};


### PR DESCRIPTION
#55  #56 #57  #58

### Problem Fixed
Location records in Provisioning did not store timezone metadata required by downstream services (such as UserPortal) for subscriber-local schedule evaluation and DST-aware calculations. Additionally, inline object creation (`createObjects`) relied on URL query parameters instead of standard HTTP request bodies, and updating inventory or venue objects with inline configurations/locations lost old reference tracking IDs, resulting in stale `inUse` reference counts in the database.

Before this change:
- **Missing Location Timezone**: Location records lacked timezone information, preventing downstream schedule evaluation based on local time zones.
- **Non-Standard REST API Contract**: `createObjects` payloads were passed as encoded URL query strings (`?createObjects={...}`), leading to URL length bottlenecks, log pollution, and non-standard REST design.
- **Stale Reference Tracking**: During inventory item or venue updates involving inline creation, `FromConfiguration` and `MoveFromLocation` were set to empty strings (`""`), causing `MoveUsage` to fail to clean up device/venue references from old configuration/location records.
- **No Subscriber Venue Filtering**: `GET /api/v1/venue` did not support filtering by subscriber ID (`subscriberId`), requiring downstream services to retrieve all venues rather than querying a specific subscriber's venue directly.
- **Repeated Same-Name Location Creation on a Venue**: Repeating an inline Location creation request for a Venue could create another Location record with the same name as the Location already linked to that Venue.
- **Venue Location Could Not Be Unlinked**: Direct Venue updates rejected an empty `location` value, preventing callers from safely clearing the Venue-to-Location reference before deleting an unused Location.

This PR resolves those issues by adding native IANA timezone support with automated database schema migration, fixing `inUse` reference tracking in database handlers, and standardizing `createObjects` payloads to use HTTP request bodies across both backend and UI.

---

### 1. IANA Timezone support for locations and database schema migration
- **REST Objects (`RESTAPI_ProvObjects.h/.cpp`)**: Added the `timezone` text field to `ProvObjects::Location`.
- **Database Storage & Schema (`storage_location.h/.cpp`)**:
  - Added `ORM::Field{"timezone", ORM::FieldType::FT_TEXT}` to `LocationDB_Fields` and updated ORM conversions.
  - Implemented `LocationDB::Upgrade` to automatically execute `ALTER TABLE locations ADD COLUMN timezone text` for existing database deployments.
- **REST Handlers (`RESTAPI_location_handler.cpp`)**: Updated Location GET/POST/PUT handlers to parse and persist the `timezone` field.
- **OpenAPI Specification (`openapi/owprov.yaml`)**: Updated the `Location` schema object to document `timezone`.

### 2. Fix stale inUse reference tracking and support Venue Location unlinking
- **Inventory Handler (`RESTAPI_inventory_handler.cpp`)**: Captured `FromConfiguration = Existing.deviceConfiguration` prior to assigning the newly created configuration ID, enabling `MoveUsage()` to correctly clean up old configuration references.
- **Venue Handler (`RESTAPI_venue_handler.cpp`)**: Captured `MoveFromLocation = Existing.location` prior to assigning the newly created location ID, enabling `MoveUsage()` to correctly clean up old location references.
- **Venue Location Unlinking (`RESTAPI_venue_handler.cpp`)**: Updated direct Venue Location validation so `"location": ""` explicitly unlinks the currently assigned Location. Non-empty unknown Location UUIDs continue to return `LocationMustExist`, while the existing `MoveUsage()` flow removes the Venue from the previous Location's `inUse` list.
- **Code Guard Cleanup**: Removed redundant `ObjectsCreated.empty()` checks around `ObjectsCreated.find()` for cleaner code execution.

### 3. Migrate createObjects payload to HTTP request body
- **Shared Helper (`RESTAPI_db_helpers.h`)**: Updated `CreateObjects` to extract the `createObjects` JSON payload directly from the parsed HTTP request body (`Poco::JSON::Object::Ptr`) and enforce rejection (`400 Bad Request`) if passed via query parameters.
- **Single Inline Object Constraint**: Restricted `createObjects.objects` to exactly 1 item to prevent reference overwrites and orphaned DB records, as `Venue` and `InventoryTag` entities only hold a single `location` or `deviceConfiguration` UUID.
- **REST Handlers (`RESTAPI_inventory_handler.cpp`, `RESTAPI_venue_handler.cpp`)**: Updated handlers to pass `ParsedBody_` into `CreateObjects()`.
- **OpenAPI Specification (`openapi/owprov.yaml`)**: Updated POST/PUT request body schemas for Inventory and Venue endpoints to document `createObjects` in the body payload.

### 4. Subscriber Venue Filtering and Venue-Scoped Location Name Check
- **Venue List Handler (`RESTAPI_venue_list_handler.cpp`)**: Added `subscriberId` filtering to `GET /api/v1/venue`.
- **Location Name Validation (`RESTAPI_venue_handler.cpp`, `RESTAPI_db_helpers.h`)**: Prevents inline creation when the requested Location name matches the Location currently linked to the same Venue. This is not a global uniqueness check; different Venues may use the same name.


## Test Evidence
Validated by Local Deployment testing:
- Successful database startup and schema upgrade adding the `timezone` column to `locations`
- Verification of Location POST/PUT/GET operations with valid IANA timezone strings (e.g. `America/New_York`)
- Verification that updating device configurations and location assignments correctly decrements the `inUse` reference count on previous records
- Verification that passing `createObjects` in the HTTP body creates the object and returns `200 OK`, while passing it as a query parameter is rejected with `400 Bad Request`
- Verification that `GET /api/v1/venue?subscriberId=<UUID>` filters and returns only the venues associated with the specified subscriber.
- Verification that inline Location creation using the same name as the Location currently linked to the Venue returns `400 Bad Request` (`Location name already exists`).
- Verification that updating a Venue with `"location": ""` clears the Venue Location reference and removes the Venue from the previous Location's `inUse` list.
- Verification that the unlinked Location can then be deleted through the existing `DELETE /api/v1/location/{uuid}` endpoint.
- End-to-end verification through UserPortal that subscriber Location deletion performs Venue unlinking followed by normal Location deletion and returns an empty `200 OK` response.



---

## Reviewer Guidance
Please review this PR against the intended `owprov` backend architecture.
Primary review focus areas:
- Verify that `LocationDB::Upgrade` safely executes the `ALTER TABLE` statement for database schema migration without affecting existing location data.
- Verify that `FromConfiguration` and `MoveFromLocation` correctly preserve previous reference IDs prior to record updates so `MoveUsage()` cleans up old references accurately.
- Verify that `CreateObjects` strictly enforces parsing from the JSON request body and returns a 400 status when query parameters are used.
- Verify that the OpenAPI specification updates in `openapi/owprov.yaml` accurately match the handler changes.
- Verify that duplicate Location-name validation is scoped to the Location currently linked to the Venue and does not enforce global uniqueness.
- Verify that a different name creates a new Location rather than updating the existing record.
- Verify that `"location": ""` is treated as an explicit Venue Location unlink operation.
- Verify that non-empty unknown Location UUIDs are still rejected with `LocationMustExist`.
- Verify that unlinking uses the existing `MoveUsage()` flow to remove the previous Venue reference and does not delete the Location automatically.


### **Out of Scope (Contact Handling in `createObjects`)**:
- The pre-existing `contact` branch in `CreateObjects` (which decodes `contact` payloads to `std::cout`) was inherited from legacy code and is intentionally out of scope for this PR. This PR focuses exclusively on IANA timezone support, `inUse` reference integrity, and `createObjects` request-body migration.

- This PR does not enforce global uniqueness for `locations.name`. Different Venues may use the same Location name.