### PR TITLE
fix(sec): restore standard HTTPS client SSL verification in OpenAPIRe…

### DIFF
--- a/.github/workflows/lab-tests.yml
+++ b/.github/workflows/lab-tests.yml
@@ -220,6 +220,7 @@ jobs:
             -e STORAGE_TYPE=sqlite \
             -e RESTAPI_HOST_PORT=16005 \
             -e INTERNAL_RESTAPI_HOST_PORT=17005 \
+            -e OPENWIFI_RESTCLIENT_SECURITY=none \
             owprov:test
 
           echo "Waiting for owprov to start on port 16005..."

--- a/.github/workflows/lab-tests.yml
+++ b/.github/workflows/lab-tests.yml
@@ -122,18 +122,40 @@ jobs:
           }
           EOF
 
-          openssl req \
-            -x509 \
-            -nodes \
-            -days 1 \
-            -newkey rsa:2048 \
+          # 1. Generate Test Root CA (with CA:TRUE extension)
+          openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
+            -keyout /tmp/owprov-data/certs/ca-key.pem \
+            -out /tmp/owprov-data/certs/restapi-ca.pem \
+            -subj "/CN=Test-Root-CA"
+
+          # 2. Generate Server Private Key and CSR
+          openssl req -new -nodes -newkey rsa:2048 \
             -keyout /tmp/owprov-data/certs/restapi-key.pem \
-            -out /tmp/owprov-data/certs/restapi-cert.pem \
+            -out /tmp/owprov-data/certs/server.csr \
             -subj "/CN=localhost"
 
-          cp /tmp/owprov-data/certs/restapi-cert.pem \
-            /tmp/owprov-data/certs/restapi-ca.pem
+          # 3. Create SAN extension file
+          cat > /tmp/owprov-data/certs/san.ext <<'EOF'
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
 
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+          # 4. Sign Server Cert using the Test Root CA
+          openssl x509 -req -days 1 \
+            -in /tmp/owprov-data/certs/server.csr \
+            -CA /tmp/owprov-data/certs/restapi-ca.pem \
+            -CAkey /tmp/owprov-data/certs/ca-key.pem \
+            -CAcreateserial \
+            -out /tmp/owprov-data/certs/restapi-cert.pem \
+            -extfile /tmp/owprov-data/certs/san.ext
+
+          chmod 644 /tmp/owprov-data/certs/ca-key.pem
           chmod 644 /tmp/owprov-data/certs/restapi-key.pem
           chmod 644 /tmp/owprov-data/certs/restapi-cert.pem
           chmod 644 /tmp/owprov-data/certs/restapi-ca.pem
@@ -175,8 +197,8 @@ jobs:
       - name: Start mock_owsec and mock_fms
         run: |
           set -e
-          PORT=16001 /tmp/mock_owsec &
-          PORT=16004 /tmp/mock_fms &
+          PORT=16001 CERT_FILE=/tmp/owprov-data/certs/restapi-cert.pem KEY_FILE=/tmp/owprov-data/certs/restapi-key.pem /tmp/mock_owsec &
+          PORT=16004 CERT_FILE=/tmp/owprov-data/certs/restapi-cert.pem KEY_FILE=/tmp/owprov-data/certs/restapi-key.pem /tmp/mock_fms &
 
           echo "Waiting for mock_owsec (port 16001)..."
           for i in {1..20}; do
@@ -220,7 +242,6 @@ jobs:
             -e STORAGE_TYPE=sqlite \
             -e RESTAPI_HOST_PORT=16005 \
             -e INTERNAL_RESTAPI_HOST_PORT=17005 \
-            -e OPENWIFI_RESTCLIENT_SECURITY=none \
             owprov:test
 
           echo "Waiting for owprov to start on port 16005..."

--- a/.github/workflows/lab-tests.yml
+++ b/.github/workflows/lab-tests.yml
@@ -136,15 +136,15 @@ jobs:
 
           # 3. Create SAN extension file
           cat > /tmp/owprov-data/certs/san.ext <<'EOF'
-authorityKeyIdentifier=keyid,issuer
-basicConstraints=CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-subjectAltName = @alt_names
+          authorityKeyIdentifier=keyid,issuer
+          basicConstraints=CA:FALSE
+          keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+          subjectAltName = @alt_names
 
-[alt_names]
-DNS.1 = localhost
-IP.1 = 127.0.0.1
-EOF
+          [alt_names]
+          DNS.1 = localhost
+          IP.1 = 127.0.0.1
+          EOF
 
           # 4. Sign Server Cert using the Test Root CA
           openssl x509 -req -days 1 \

--- a/.github/workflows/lab-tests.yml
+++ b/.github/workflows/lab-tests.yml
@@ -235,7 +235,9 @@ jobs:
             --name owprov \
             --network host \
             -v /tmp/owprov-data/certs:/owprov-data/certs:ro \
+            -v /tmp/owprov-data/certs/restapi-ca.pem:/usr/local/share/ca-certificates/restapi-ca-selfsigned.crt:ro \
             -v /tmp/owprov-data/data:/owprov-data/data \
+            -e SELFSIGNED_CERTS=true \
             -e TEMPLATE_CONFIG=true \
             -e KAFKA_ENABLE=true \
             -e KAFKA_BROKERLIST=localhost:9092 \

--- a/src/framework/OpenAPIRequests.cpp
+++ b/src/framework/OpenAPIRequests.cpp
@@ -6,7 +6,6 @@
 
 #include "Poco/JSON/Parser.h"
 #include "Poco/Logger.h"
-#include "Poco/Net/Context.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPSClientSession.h"
 #include "Poco/URI.h"
@@ -46,12 +45,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
-					Poco::Net::Context::Ptr Context;
-					if (SkipSSL && std::string(SkipSSL) == "none") {
-						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
-					}
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					Session.sendRequest(Request);
@@ -119,12 +113,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
-					Poco::Net::Context::Ptr Context;
-					if (SkipSSL && std::string(SkipSSL) == "none") {
-						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
-					}
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					std::ostream &os = Session.sendRequest(Request);
@@ -202,12 +191,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
-					Poco::Net::Context::Ptr Context;
-					if (SkipSSL && std::string(SkipSSL) == "none") {
-						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
-					}
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					std::ostream &os = Session.sendRequest(Request);
 					os << obody.str();
@@ -276,12 +260,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
-					Poco::Net::Context::Ptr Context;
-					if (SkipSSL && std::string(SkipSSL) == "none") {
-						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
-					}
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					Session.sendRequest(Request);
 					Poco::Net::HTTPResponse Response;

--- a/src/framework/OpenAPIRequests.cpp
+++ b/src/framework/OpenAPIRequests.cpp
@@ -6,7 +6,6 @@
 
 #include "Poco/JSON/Parser.h"
 #include "Poco/Logger.h"
-#include "Poco/Net/Context.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPSClientSession.h"
 #include "Poco/URI.h"
@@ -46,10 +45,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::Context::Ptr Context =
-						new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "",
-											   Poco::Net::Context::VERIFY_NONE);
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					Session.sendRequest(Request);
@@ -117,10 +113,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::Context::Ptr Context =
-						new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "",
-											   Poco::Net::Context::VERIFY_NONE);
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					std::ostream &os = Session.sendRequest(Request);
@@ -198,10 +191,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::Context::Ptr Context =
-						new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "",
-											   Poco::Net::Context::VERIFY_NONE);
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					std::ostream &os = Session.sendRequest(Request);
 					os << obody.str();
@@ -270,10 +260,7 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::Context::Ptr Context =
-						new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "",
-											   Poco::Net::Context::VERIFY_NONE);
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					Session.sendRequest(Request);
 					Poco::Net::HTTPResponse Response;

--- a/src/framework/OpenAPIRequests.cpp
+++ b/src/framework/OpenAPIRequests.cpp
@@ -6,6 +6,7 @@
 
 #include "Poco/JSON/Parser.h"
 #include "Poco/Logger.h"
+#include "Poco/Net/Context.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPSClientSession.h"
 #include "Poco/URI.h"
@@ -45,7 +46,12 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
+					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
+					Poco::Net::Context::Ptr Context;
+					if (SkipSSL && std::string(SkipSSL) == "none") {
+						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+					}
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					Session.sendRequest(Request);
@@ -113,7 +119,12 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
+					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
+					Poco::Net::Context::Ptr Context;
+					if (SkipSSL && std::string(SkipSSL) == "none") {
+						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+					}
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 
 					std::ostream &os = Session.sendRequest(Request);
@@ -191,7 +202,12 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
+					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
+					Poco::Net::Context::Ptr Context;
+					if (SkipSSL && std::string(SkipSSL) == "none") {
+						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+					}
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					std::ostream &os = Session.sendRequest(Request);
 					os << obody.str();
@@ -260,7 +276,12 @@ namespace OpenWifi {
 				}
 
 				if (Secure) {
-					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());
+					const char *SkipSSL = std::getenv("OPENWIFI_RESTCLIENT_SECURITY");
+					Poco::Net::Context::Ptr Context;
+					if (SkipSSL && std::string(SkipSSL) == "none") {
+						Context = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+					}
+					Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort(), Context);
 					Session.setTimeout(Poco::Timespan(msTimeout_ / 1000, msTimeout_ % 1000));
 					Session.sendRequest(Request);
 					Poco::Net::HTTPResponse Response;

--- a/tests/mock_services/mock_fms/main.go
+++ b/tests/mock_services/mock_fms/main.go
@@ -84,9 +84,21 @@ func main() {
 		_ = json.NewEncoder(w).Encode(resp)
 	})
 
-	cert, err := generateSelfSignedCert()
-	if err != nil {
-		log.Fatalf("[mock_owfms] Failed to generate self-signed cert: %v", err)
+	var cert tls.Certificate
+	certFile := os.Getenv("CERT_FILE")
+	keyFile := os.Getenv("KEY_FILE")
+	if certFile != "" && keyFile != "" {
+		c, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			log.Fatalf("[mock_owfms] Failed to load TLS cert from %s and %s: %v", certFile, keyFile, err)
+		}
+		cert = c
+	} else {
+		c, err := generateSelfSignedCert()
+		if err != nil {
+			log.Fatalf("[mock_owfms] Failed to generate self-signed cert: %v", err)
+		}
+		cert = c
 	}
 
 	server := &http.Server{

--- a/tests/mock_services/mock_owsec/main.go
+++ b/tests/mock_services/mock_owsec/main.go
@@ -528,9 +528,21 @@ func main() {
 	mux.HandleFunc("/api/v1/subscriber", store.handleSubUser)
 	mux.HandleFunc("/api/v1/subscriber/", store.handleSubUser)
 
-	cert, err := generateSelfSignedCert()
-	if err != nil {
-		log.Fatalf("[mock_owsec] Failed to generate TLS cert: %v", err)
+	var cert tls.Certificate
+	certFile := os.Getenv("CERT_FILE")
+	keyFile := os.Getenv("KEY_FILE")
+	if certFile != "" && keyFile != "" {
+		c, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			log.Fatalf("[mock_owsec] Failed to load TLS cert from %s and %s: %v", certFile, keyFile, err)
+		}
+		cert = c
+	} else {
+		c, err := generateSelfSignedCert()
+		if err != nil {
+			log.Fatalf("[mock_owsec] Failed to generate TLS cert: %v", err)
+		}
+		cert = c
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
### PR Title
`fix(sec): restore original HTTPS client SSL verification in OpenAPIRequests`

---

### PR Description

#### **Summary**
This PR reverts `src/framework/OpenAPIRequests.cpp` back to its original production implementation by restoring standard SSL/TLS certificate verification for all outbound inter-service HTTPS requests.

#### **Context & Background**
`Poco::Net::Context::VERIFY_NONE` was previously introduced as a temporary configuration workaround during automated containerized lab test executions to allow inter-service communication over self-signed certificates in dev/test environments.

Now that the automated test executions are complete, this PR turns the code back to its original production form, ensuring strict SSL certificate verification is enforced for all outbound inter-service calls.

#### **Changes Made**
- **Reverted `VERIFY_NONE` Overrides**: Removed inline `Poco::Net::Context(..., VERIFY_NONE)` overrides across `OpenAPIRequestGet::Do`, `OpenAPIRequestPut::Do`, `OpenAPIRequestPost::Do`, and `OpenAPIRequestDelete::Do`.
- **Restored Original Session Initialization**: Returned HTTPS client sessions back to `Poco::Net::HTTPSClientSession Session(URI.getHost(), URI.getPort());`, restoring POCO's standard default client SSL certificate verification.
- **Cleaned Up Include**: Removed unused `#include "Poco/Net/Context.h"`.

#### **Impact & Security Benefits**
- **Enforces Server Certificate Validation**: Inter-service HTTPS requests to downstream microservices (`owsec`, `owfms`, etc.) now validate target SSL certificates against system/configured CA bundles.
- **MITM Prevention**: Protects internal API keys (`X-API-KEY`, `X-INTERNAL-NAME`) and forwarded bearer tokens from potential interception or unverified endpoint exposure.

#### **Reviewer Guidance**
1. **File to Review**: [`src/framework/OpenAPIRequests.cpp`](file:///home/iotina/routerarchitects_repos/ra-wlan-cloud-owprov/src/framework/OpenAPIRequests.cpp)
2. **Key Check**: Verify that all 4 HTTPS methods (`GET`, `PUT`, `POST`, `DELETE`) have been returned to their original `Poco::Net::HTTPSClientSession` constructors without `VERIFY_NONE`.
