### PR TITLE
Add shared database transaction support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,3 +243,16 @@ target_link_libraries(owprov PUBLIC
         CppKafka::cppkafka
         resolv
         fmt::fmt)
+
+add_executable(db_transaction_test
+        tests/framework_tests/DbTransaction_test.cpp
+)
+
+target_link_libraries(db_transaction_test PRIVATE
+        ${Poco_LIBRARIES}
+        fmt::fmt)
+
+enable_testing()
+add_test(NAME db_transaction_test COMMAND db_transaction_test)
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ FROM build-base AS owprov-build
 ADD CMakeLists.txt build /owprov/
 ADD cmake /owprov/cmake
 ADD src /owprov/src
+ADD tests/framework_tests /owprov/tests/framework_tests
 ADD .git /owprov/.git
 
 COPY --from=poco-build /usr/local/include /usr/local/include
@@ -72,6 +73,7 @@ RUN mkdir cmake-build
 WORKDIR /owprov/cmake-build
 RUN cmake ..
 RUN cmake --build . --config Release -j8
+RUN ctest --output-on-failure
 
 FROM debian:$DEBIAN_VERSION
 

--- a/src/StorageService.h
+++ b/src/StorageService.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "framework/DbTransaction.h"
 #include "framework/MicroServiceFuncs.h"
 #include "framework/StorageClass.h"
 #include "storage/storage_configurations.h"
@@ -74,6 +75,11 @@ namespace OpenWifi {
         inline OpenWifi::GLBLRCertsDB &GLBLRCertsDB() { return *GLBLRCertsDB_; }
         inline OpenWifi::OrionAccountsDB &OrionAccountsDB() { return *OrionAccountsDB_; }
         inline OpenWifi::RadiusEndpointDB &RadiusEndpointDB() { return *RadiusEndpointDB_; }
+
+		// Starts a transaction using one pooled DB session.
+		[[nodiscard]] inline DbTransaction BeginTransaction() {
+			return DbTransaction(Pool().get(), Logger());
+		}
 
 		bool Validate(const Poco::URI::QueryParameters &P, RESTAPI::Errors::msg &Error);
 		bool Validate(const Types::StringVec &P, std::string &Error);

--- a/src/framework/DbTransaction.h
+++ b/src/framework/DbTransaction.h
@@ -17,6 +17,7 @@
 
 namespace OpenWifi {
 
+	// Note: Keep transactions narrow and DB-only. Perform network/JSON operations before opening DbTransaction to prevent pool exhaustion.
 	class DbTransaction final {
 	  public:
 		using PostCommitFunc = std::function<void()>;
@@ -41,7 +42,7 @@ namespace OpenWifi {
 			return session_;
 		}
 
-		// Registers a callback to execute ONLY after the database transaction commits successfully.
+		// Registers a callback to execute ONLY after DB commit succeeds. Callbacks run synchronously and must remain fast/lightweight (e.g. cache sync).
 		void AfterCommit(PostCommitFunc fn) {
 			if (!transaction_.isActive()) {
 				throw Poco::IllegalStateException("Database transaction is not active");

--- a/src/framework/DbTransaction.h
+++ b/src/framework/DbTransaction.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -24,7 +25,9 @@ namespace OpenWifi {
 
 		// Owns one pooled session and starts a transaction on it.
 		explicit DbTransaction(Poco::Data::Session session, Poco::Logger &logger)
-			: session_(std::move(session)), logger_(logger), transaction_(session_, &logger_) {}
+			: logger_(logger) {
+			resources_.emplace(std::move(session), logger_);
+		}
 
 		// Poco::Data::Transaction rolls back automatically if still active.
 		// Pending post-commit actions are discarded on destruction.
@@ -35,16 +38,19 @@ namespace OpenWifi {
 		DbTransaction(DbTransaction &&) = delete;
 		DbTransaction &operator=(DbTransaction &&) = delete;
 
+		// Returned reference is valid only while the transaction is active.
 		Poco::Data::Session &Session() {
-			if (!transaction_.isActive()) {
+			if (!resources_ || !resources_->transaction.isActive()) {
 				throw Poco::IllegalStateException("Database transaction is not active");
 			}
-			return session_;
+
+			return resources_->session;
 		}
 
-		// Registers a callback to execute ONLY after DB commit succeeds. Callbacks run synchronously and must remain fast/lightweight (e.g. cache sync).
+		// Runs only after a successful DB commit.
+		// Callbacks are synchronous and run after DB resources are released.
 		void AfterCommit(PostCommitFunc fn) {
-			if (!transaction_.isActive()) {
+			if (!resources_ || !resources_->transaction.isActive()) {
 				throw Poco::IllegalStateException("Database transaction is not active");
 			}
 			if (fn) {
@@ -53,60 +59,79 @@ namespace OpenWifi {
 		}
 
 		[[nodiscard]] bool Commit() noexcept {
+			std::vector<PostCommitFunc> actions;
+
 			try {
-				if (!transaction_.isActive()) {
+				if (!resources_ || !resources_->transaction.isActive()) {
 					return false;
 				}
 
-				transaction_.commit();
+				resources_->transaction.commit();
 
-				// Execute queued post-commit actions only after DB commit succeeds
-				for (const auto &fn : after_commit_actions_) {
-					try {
-						fn();
-					} catch (const Poco::Exception &e) {
-						logger_.error("Error in post-commit action: " + e.displayText());
-					} catch (...) {
-						logger_.error("Error in post-commit action: unknown exception");
-					}
-				}
-				after_commit_actions_.clear();
-				return true;
+				actions.swap(after_commit_actions_);
+
+				// Release DB transaction and pooled session before callbacks.
+				resources_.reset();
+
 			} catch (const Poco::Exception &e) {
 				logger_.error("Failed to commit database transaction: " + e.displayText());
+				after_commit_actions_.clear();
+				return false;
 			} catch (...) {
 				logger_.error("Failed to commit database transaction: unknown exception");
+				after_commit_actions_.clear();
+				return false;
 			}
 
-			after_commit_actions_.clear();
-			return false;
+			for (const auto &fn : actions) {
+				try {
+					fn();
+				} catch (const Poco::Exception &e) {
+					logger_.error("Error in post-commit action: " + e.displayText());
+				} catch (...) {
+					logger_.error("Error in post-commit action: unknown exception");
+				}
+			}
+
+			return true;
 		}
 
 		[[nodiscard]] bool Rollback() noexcept {
+			after_commit_actions_.clear();
+
 			try {
-				after_commit_actions_.clear();
-				if (!transaction_.isActive()) {
+				if (!resources_ || !resources_->transaction.isActive()) {
 					return false;
 				}
 
-				transaction_.rollback();
+				resources_->transaction.rollback();
+
+				// Return the session immediately.
+				resources_.reset();
+
 				return true;
+
 			} catch (const Poco::Exception &e) {
 				logger_.error("Failed to roll back database transaction: " + e.displayText());
 			} catch (...) {
 				logger_.error("Failed to roll back database transaction: unknown exception");
 			}
 
-			after_commit_actions_.clear();
 			return false;
 		}
 
 	  private:
-		Poco::Data::Session session_;
+		struct Resources {
+			Resources(Poco::Data::Session dbSession, Poco::Logger &logger)
+				: session(std::move(dbSession)), transaction(session, &logger) {}
+
+			Poco::Data::Session session;
+			Poco::Data::Transaction transaction;
+		};
+
 		Poco::Logger &logger_;
-		Poco::Data::Transaction transaction_;
+		std::optional<Resources> resources_;
 		std::vector<PostCommitFunc> after_commit_actions_;
 	};
 
 } // namespace OpenWifi
-

--- a/src/framework/DbTransaction.h
+++ b/src/framework/DbTransaction.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <functional>
 #include <utility>
+#include <vector>
 
 #include "Poco/Data/Session.h"
 #include "Poco/Data/Transaction.h"
@@ -17,11 +19,14 @@ namespace OpenWifi {
 
 	class DbTransaction final {
 	  public:
+		using PostCommitFunc = std::function<void()>;
+
 		// Owns one pooled session and starts a transaction on it.
 		explicit DbTransaction(Poco::Data::Session session, Poco::Logger &logger)
 			: session_(std::move(session)), logger_(logger), transaction_(session_, &logger_) {}
 
 		// Poco::Data::Transaction rolls back automatically if still active.
+		// Pending post-commit actions are discarded on destruction.
 		~DbTransaction() = default;
 
 		DbTransaction(const DbTransaction &) = delete;
@@ -36,6 +41,16 @@ namespace OpenWifi {
 			return session_;
 		}
 
+		// Registers a callback to execute ONLY after the database transaction commits successfully.
+		void AfterCommit(PostCommitFunc fn) {
+			if (!transaction_.isActive()) {
+				throw Poco::IllegalStateException("Database transaction is not active");
+			}
+			if (fn) {
+				after_commit_actions_.push_back(std::move(fn));
+			}
+		}
+
 		[[nodiscard]] bool Commit() noexcept {
 			try {
 				if (!transaction_.isActive()) {
@@ -43,6 +58,18 @@ namespace OpenWifi {
 				}
 
 				transaction_.commit();
+
+				// Execute queued post-commit actions only after DB commit succeeds
+				for (const auto &fn : after_commit_actions_) {
+					try {
+						fn();
+					} catch (const Poco::Exception &e) {
+						logger_.error("Error in post-commit action: " + e.displayText());
+					} catch (...) {
+						logger_.error("Error in post-commit action: unknown exception");
+					}
+				}
+				after_commit_actions_.clear();
 				return true;
 			} catch (const Poco::Exception &e) {
 				logger_.error("Failed to commit database transaction: " + e.displayText());
@@ -50,11 +77,13 @@ namespace OpenWifi {
 				logger_.error("Failed to commit database transaction: unknown exception");
 			}
 
+			after_commit_actions_.clear();
 			return false;
 		}
 
 		[[nodiscard]] bool Rollback() noexcept {
 			try {
+				after_commit_actions_.clear();
 				if (!transaction_.isActive()) {
 					return false;
 				}
@@ -67,6 +96,7 @@ namespace OpenWifi {
 				logger_.error("Failed to roll back database transaction: unknown exception");
 			}
 
+			after_commit_actions_.clear();
 			return false;
 		}
 
@@ -74,6 +104,8 @@ namespace OpenWifi {
 		Poco::Data::Session session_;
 		Poco::Logger &logger_;
 		Poco::Data::Transaction transaction_;
+		std::vector<PostCommitFunc> after_commit_actions_;
 	};
 
 } // namespace OpenWifi
+

--- a/src/framework/DbTransaction.h
+++ b/src/framework/DbTransaction.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include <utility>
+
+#include "Poco/Data/Session.h"
+#include "Poco/Data/Transaction.h"
+#include "Poco/Exception.h"
+#include "Poco/Logger.h"
+
+namespace OpenWifi {
+
+	class DbTransaction final {
+	  public:
+		// Owns one pooled session and starts a transaction on it.
+		explicit DbTransaction(Poco::Data::Session session, Poco::Logger &logger)
+			: session_(std::move(session)), logger_(logger), transaction_(session_, &logger_) {}
+
+		// Poco::Data::Transaction rolls back automatically if still active.
+		~DbTransaction() = default;
+
+		DbTransaction(const DbTransaction &) = delete;
+		DbTransaction &operator=(const DbTransaction &) = delete;
+		DbTransaction(DbTransaction &&) = delete;
+		DbTransaction &operator=(DbTransaction &&) = delete;
+
+		Poco::Data::Session &Session() {
+			if (!transaction_.isActive()) {
+				throw Poco::IllegalStateException("Database transaction is not active");
+			}
+			return session_;
+		}
+
+		[[nodiscard]] bool Commit() noexcept {
+			try {
+				if (!transaction_.isActive()) {
+					return false;
+				}
+
+				transaction_.commit();
+				return true;
+			} catch (const Poco::Exception &e) {
+				logger_.error("Failed to commit database transaction: " + e.displayText());
+			} catch (...) {
+				logger_.error("Failed to commit database transaction: unknown exception");
+			}
+
+			return false;
+		}
+
+		[[nodiscard]] bool Rollback() noexcept {
+			try {
+				if (!transaction_.isActive()) {
+					return false;
+				}
+
+				transaction_.rollback();
+				return true;
+			} catch (const Poco::Exception &e) {
+				logger_.error("Failed to roll back database transaction: " + e.displayText());
+			} catch (...) {
+				logger_.error("Failed to roll back database transaction: unknown exception");
+			}
+
+			return false;
+		}
+
+	  private:
+		Poco::Data::Session session_;
+		Poco::Logger &logger_;
+		Poco::Data::Transaction transaction_;
+	};
+
+} // namespace OpenWifi

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -201,6 +201,7 @@ namespace ORM {
 		virtual void Delete(const std::string &FieldName, const std::string &Value) = 0;
 
 		// Last-resort consistency recovery when targeted cache invalidation fails.
+		// Post-commit cache recovery is best-effort and does not alter a successful DB commit.
 		virtual void InvalidateAll() = 0;
 
 	  private:
@@ -1159,7 +1160,15 @@ namespace ORM {
 				std::string St = "delete from " + TableName_ + " where " + FieldName + "=?";
 				auto tValue{Value};
 				Delete << ConvertParams(St), Poco::Data::Keywords::use(tValue);
-				Delete.execute();
+				const auto AffectedRows = Delete.execute();
+				if (AffectedRows != 1) {
+					Logger_.warning(
+						"DeleteRecord affected " + std::to_string(AffectedRows) +
+						" rows in table '" + TableName_ +
+						"' for field '" + FieldName + "'."
+					);
+					return false;
+				}
 				if (Cache_) {
 					std::string fieldName{FieldName};
 					std::string valStr{to_string(Value)};

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <array>
+#include <exception>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -1134,9 +1135,10 @@ namespace ORM {
 					return false;
 				}
 				if (Cache_) {
-					tx.AfterCommit([this, R]() {
-						if (Cache_)
-							Cache_->UpdateCache(R);
+					std::string fieldName{FieldName};
+					std::string valStr{to_string(Value)};
+					tx.AfterCommit([this, R, fieldName, valStr]() {
+						UpdateCacheOrInvalidate(R, fieldName, valStr);
 					});
 				}
 				return true;
@@ -1194,6 +1196,39 @@ namespace ORM {
 		DBCache<RecordType> *Cache_ = nullptr;
 
 	  private:
+		void UpdateCacheOrInvalidate(const RecordType &R, const std::string &fieldName,
+		                             const std::string &value) {
+			if (!Cache_)
+				return;
+
+			try {
+				Cache_->UpdateCache(R);
+				return;
+			} catch (const Poco::Exception &E) {
+				Logger_.error(
+					"UpdateCache failed post-commit, invalidating cache entry: " +
+					E.displayText());
+			} catch (const std::exception &E) {
+				Logger_.error(
+					"UpdateCache failed post-commit, invalidating cache entry: " +
+					std::string(E.what()));
+			} catch (...) {
+				Logger_.error(
+					"UpdateCache failed post-commit, invalidating cache entry: unknown exception");
+			}
+
+			try {
+				Cache_->Delete(fieldName, value);
+			} catch (const Poco::Exception &E) {
+				Logger_.error(
+					"Failed to invalidate cache entry after UpdateCache failure: " +
+					E.displayText());
+			} catch (...) {
+				Logger_.error(
+					"Failed to invalidate cache entry after UpdateCache failure: unknown exception");
+			}
+		}
+
 		std::string CreateFields_;
 		std::string SelectFields_;
 		std::string SelectList_;

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -23,6 +23,7 @@
 #include "Poco/Logger.h"
 #include "Poco/StringTokenizer.h"
 #include "Poco/Tuple.h"
+#include "DbTransaction.h"
 #include "StorageClass.h"
 
 #include "fmt/format.h"
@@ -1084,15 +1085,25 @@ namespace ORM {
 			return false;
 		}
 
-		bool CreateRecord(Poco::Data::Session &session, const RecordType &R) {
+		// Transaction-aware ORM operations for caller-owned transactions.
+		// Reads use the transaction session directly (e.g., GetRecord(tx.Session(), ...)).
+		// Create/Update/Delete writes register cache changes that execute
+		// only after a successful DbTransaction::Commit().
+		bool CreateRecord(OpenWifi::DbTransaction &tx, const RecordType &R) {
 			try {
-				Poco::Data::Statement Insert(session);
+				Poco::Data::Statement Insert(tx.Session());
 				RecordTuple RT;
 				Convert(R, RT);
 				std::string St = "insert into  " + TableName_ + " ( " + SelectFields_ +
 				                 " ) values " + SelectList_;
 				Insert << ConvertParams(St), Poco::Data::Keywords::use(RT);
 				Insert.execute();
+				if (Cache_) {
+					tx.AfterCommit([this, R]() {
+						if (Cache_)
+							Cache_->Create(R);
+					});
+				}
 				return true;
 			} catch (const Poco::Exception &E) {
 				Logger_.log(E);
@@ -1101,11 +1112,11 @@ namespace ORM {
 		}
 
 		template <typename T>
-		bool UpdateRecord(Poco::Data::Session &session, field_name_t FieldName, const T &Value,
+		bool UpdateRecord(OpenWifi::DbTransaction &tx, field_name_t FieldName, const T &Value,
 		                  const RecordType &R) {
 			try {
 				assert(ValidFieldName(FieldName));
-				Poco::Data::Statement Update(session);
+				Poco::Data::Statement Update(tx.Session());
 				RecordTuple RT;
 				Convert(R, RT);
 				auto tValue(Value);
@@ -1122,6 +1133,12 @@ namespace ORM {
 					);
 					return false;
 				}
+				if (Cache_) {
+					tx.AfterCommit([this, R]() {
+						if (Cache_)
+							Cache_->UpdateCache(R);
+					});
+				}
 				return true;
 			} catch (const Poco::Exception &E) {
 				Logger_.log(E);
@@ -1130,14 +1147,22 @@ namespace ORM {
 		}
 
 		template <typename T>
-		bool DeleteRecord(Poco::Data::Session &session, field_name_t FieldName, const T &Value) {
+		bool DeleteRecord(OpenWifi::DbTransaction &tx, field_name_t FieldName, const T &Value) {
 			try {
 				assert(ValidFieldName(FieldName));
-				Poco::Data::Statement Delete(session);
+				Poco::Data::Statement Delete(tx.Session());
 				std::string St = "delete from " + TableName_ + " where " + FieldName + "=?";
 				auto tValue{Value};
 				Delete << ConvertParams(St), Poco::Data::Keywords::use(tValue);
 				Delete.execute();
+				if (Cache_) {
+					std::string fieldName{FieldName};
+					std::string valStr{to_string(Value)};
+					tx.AfterCommit([this, fieldName, valStr]() {
+						if (Cache_)
+							Cache_->Delete(fieldName, valStr);
+					});
+				}
 				return true;
 			} catch (const Poco::Exception &E) {
 				Logger_.log(E);
@@ -1145,6 +1170,7 @@ namespace ORM {
 			return false;
 		}
 
+		// Low-level session operation for bulk deletion. Automatic cache synchronization is not provided for arbitrary bulk deletes.
 		bool DeleteRecords(Poco::Data::Session &session, const std::string &WhereClause) {
 			try {
 				assert(!WhereClause.empty());

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -1023,6 +1023,142 @@ namespace ORM {
 				F.push_back(field);
 		}
 
+		// Session-aware overloads for caller-owned transactions.
+		// These methods do not acquire a session, manage the transaction,
+		// or update Cache_. Cache changes must happen after a successful commit.
+
+		template <typename T>
+		bool GetRecord(Poco::Data::Session &session, field_name_t FieldName, const T &Value,
+		               RecordType &R) {
+			try {
+				assert(ValidFieldName(FieldName));
+				Poco::Data::Statement Select(session);
+				RecordTuple RT;
+				std::string St = "select " + SelectFields_ + " from " + TableName_ + " where " +
+				                 FieldName + "=? limit 1";
+				auto tValue{Value};
+				Select << ConvertParams(St), Poco::Data::Keywords::into(RT),
+				    Poco::Data::Keywords::use(tValue);
+				if (Select.execute() == 1) {
+					Convert(RT, R);
+					return true;
+				}
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+			return false;
+		}
+
+		bool GetRecords(Poco::Data::Session &session,
+		                uint64_t Offset,
+		                uint64_t HowMany,
+		                RecordVec &Records,
+		                const std::string &Where = "",
+		                const std::string &OrderBy = "") {
+			try {
+				Poco::Data::Statement Select(session);
+				RecordList RL;
+
+				std::string St =
+					"select " + SelectFields_ + " from " + TableName_ +
+					(Where.empty() ? "" : " where " + Where) +
+					OrderBy + ComputeRange(Offset, HowMany);
+
+				Select << St, Poco::Data::Keywords::into(RL);
+				Select.execute();
+
+				if (Select.rowsExtracted() > 0) {
+					for (auto &i : RL) {
+						RecordType R;
+						Convert(i, R);
+						Records.emplace_back(R);
+					}
+					return true;
+				}
+
+				return false;
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+
+			return false;
+		}
+
+		bool CreateRecord(Poco::Data::Session &session, const RecordType &R) {
+			try {
+				Poco::Data::Statement Insert(session);
+				RecordTuple RT;
+				Convert(R, RT);
+				std::string St = "insert into  " + TableName_ + " ( " + SelectFields_ +
+				                 " ) values " + SelectList_;
+				Insert << ConvertParams(St), Poco::Data::Keywords::use(RT);
+				Insert.execute();
+				return true;
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+			return false;
+		}
+
+		template <typename T>
+		bool UpdateRecord(Poco::Data::Session &session, field_name_t FieldName, const T &Value,
+		                  const RecordType &R) {
+			try {
+				assert(ValidFieldName(FieldName));
+				Poco::Data::Statement Update(session);
+				RecordTuple RT;
+				Convert(R, RT);
+				auto tValue(Value);
+				std::string St = "update " + TableName_ + " set " + UpdateFields_ +
+				                 " where " + FieldName + "=?";
+				Update << ConvertParams(St), Poco::Data::Keywords::use(RT),
+				    Poco::Data::Keywords::use(tValue);
+				const auto AffectedRows = Update.execute();
+				if (AffectedRows != 1) {
+					Logger_.warning(
+						"UpdateRecord affected " + std::to_string(AffectedRows) +
+						" rows in table '" + TableName_ +
+						"' for field '" + FieldName + "'."
+					);
+					return false;
+				}
+				return true;
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+			return false;
+		}
+
+		template <typename T>
+		bool DeleteRecord(Poco::Data::Session &session, field_name_t FieldName, const T &Value) {
+			try {
+				assert(ValidFieldName(FieldName));
+				Poco::Data::Statement Delete(session);
+				std::string St = "delete from " + TableName_ + " where " + FieldName + "=?";
+				auto tValue{Value};
+				Delete << ConvertParams(St), Poco::Data::Keywords::use(tValue);
+				Delete.execute();
+				return true;
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+			return false;
+		}
+
+		bool DeleteRecords(Poco::Data::Session &session, const std::string &WhereClause) {
+			try {
+				assert(!WhereClause.empty());
+				Poco::Data::Statement Delete(session);
+				std::string St = "delete from " + TableName_ + " where " + WhereClause;
+				Delete << St;
+				Delete.execute();
+				return true;
+			} catch (const Poco::Exception &E) {
+				Logger_.log(E);
+			}
+			return false;
+		}
+
 	  protected:
 		std::string TableName_;
 		OpenWifi::DBType Type_;
@@ -1040,3 +1176,4 @@ namespace ORM {
 		std::map<std::string, int> FieldNames_;
 	};
 } // namespace ORM
+

--- a/src/framework/orm.h
+++ b/src/framework/orm.h
@@ -200,6 +200,9 @@ namespace ORM {
 		virtual void UpdateCache(const RecordType &R) = 0;
 		virtual void Delete(const std::string &FieldName, const std::string &Value) = 0;
 
+		// Last-resort consistency recovery when targeted cache invalidation fails.
+		virtual void InvalidateAll() = 0;
+
 	  private:
 		size_t Size_ = 0;
 		uint64_t Timeout_ = 0;
@@ -1161,8 +1164,7 @@ namespace ORM {
 					std::string fieldName{FieldName};
 					std::string valStr{to_string(Value)};
 					tx.AfterCommit([this, fieldName, valStr]() {
-						if (Cache_)
-							Cache_->Delete(fieldName, valStr);
+						InvalidateCacheEntry(fieldName, valStr);
 					});
 				}
 				return true;
@@ -1196,8 +1198,35 @@ namespace ORM {
 		DBCache<RecordType> *Cache_ = nullptr;
 
 	  private:
-		void UpdateCacheOrInvalidate(const RecordType &R, const std::string &fieldName,
-		                             const std::string &value) {
+		void InvalidateCacheEntry(const std::string &fieldName, const std::string &value) {
+			if (!Cache_)
+				return;
+
+			try {
+				Cache_->Delete(fieldName, value);
+				return;
+			} catch (const Poco::Exception &E) {
+				Logger_.error("Cache entry invalidation failed: " + E.displayText());
+			} catch (const std::exception &E) {
+				Logger_.error("Cache entry invalidation failed: " + std::string(E.what()));
+			} catch (...) {
+				Logger_.error("Cache entry invalidation failed: unknown exception");
+			}
+
+			Logger_.error("Falling back to full cache invalidation after targeted invalidation failure.");
+
+			try {
+				Cache_->InvalidateAll();
+			} catch (const Poco::Exception &E) {
+				Logger_.error("Full cache invalidation failed: " + E.displayText());
+			} catch (const std::exception &E) {
+				Logger_.error("Full cache invalidation failed: " + std::string(E.what()));
+			} catch (...) {
+				Logger_.error("Full cache invalidation failed: unknown exception");
+			}
+		}
+
+		void UpdateCacheOrInvalidate(const RecordType &R, const std::string &fieldName, const std::string &value) {
 			if (!Cache_)
 				return;
 
@@ -1205,28 +1234,14 @@ namespace ORM {
 				Cache_->UpdateCache(R);
 				return;
 			} catch (const Poco::Exception &E) {
-				Logger_.error(
-					"UpdateCache failed post-commit, invalidating cache entry: " +
-					E.displayText());
+				Logger_.error("UpdateCache failed post-commit: " + E.displayText());
 			} catch (const std::exception &E) {
-				Logger_.error(
-					"UpdateCache failed post-commit, invalidating cache entry: " +
-					std::string(E.what()));
+				Logger_.error("UpdateCache failed post-commit: " + std::string(E.what()));
 			} catch (...) {
-				Logger_.error(
-					"UpdateCache failed post-commit, invalidating cache entry: unknown exception");
+				Logger_.error("UpdateCache failed post-commit: unknown exception");
 			}
 
-			try {
-				Cache_->Delete(fieldName, value);
-			} catch (const Poco::Exception &E) {
-				Logger_.error(
-					"Failed to invalidate cache entry after UpdateCache failure: " +
-					E.displayText());
-			} catch (...) {
-				Logger_.error(
-					"Failed to invalidate cache entry after UpdateCache failure: unknown exception");
-			}
+			InvalidateCacheEntry(fieldName, value);
 		}
 
 		std::string CreateFields_;

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -56,7 +56,14 @@ namespace OpenWifi {
 			return false;
 		}
 
+		void SetThrowOnUpdateCache(bool shouldThrow) {
+			throwOnUpdateCache_ = shouldThrow;
+		}
+
 		void UpdateCache(const TestRecord &R) override {
+			if (throwOnUpdateCache_) {
+				throw Poco::Exception("Mock UpdateCache simulated failure");
+			}
 			cache_map_[R.id] = R;
 		}
 
@@ -76,6 +83,7 @@ namespace OpenWifi {
 
 	  private:
 		std::map<std::string, TestRecord> cache_map_;
+		bool throwOnUpdateCache_ = false;
 	};
 
 } // namespace OpenWifi
@@ -345,6 +353,66 @@ int main() {
 		std::cout << "PASSED" << std::endl;
 	}
 
+	// -------------------------------------------------------------------------
+	// Test 7: Targeted Cache Invalidation Fallback When UpdateCache() Fails
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 7: Targeted Cache Invalidation Fallback on UpdateCache() Failure... " << std::flush;
+		mockCache.Clear();
+		mockCache.SetThrowOnUpdateCache(false);
+
+		// Pre-populate database & cache
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recK{"rec-111", "Record K", "Val K Initial"};
+			OpenWifi::TestRecord recL{"rec-112", "Record L", "Val L Unrelated"};
+			TEST_ASSERT(db.CreateRecord(tx, recK) == true, "Failed to create recK");
+			TEST_ASSERT(db.CreateRecord(tx, recL) == true, "Failed to create recL");
+			TEST_ASSERT(tx.Commit() == true, "Failed to commit initial records for Test 7");
+		}
+
+		TEST_ASSERT(mockCache.Contains("rec-111") == true, "recK missing from cache");
+		TEST_ASSERT(mockCache.Contains("rec-112") == true, "recL missing from cache");
+
+		// Perform update inside transaction with mockCache set to throw on UpdateCache
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recK_updated{"rec-111", "Record K", "Val K Updated"};
+			TEST_ASSERT(db.UpdateRecord(tx, "id", "rec-111", recK_updated) == true, "UpdateRecord failed inside tx");
+
+			mockCache.SetThrowOnUpdateCache(true);
+			TEST_ASSERT(tx.Commit() == true, "Commit() must succeed even if post-commit UpdateCache throws");
+		}
+
+		// Verify 1: DB update remains committed
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkK;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-111", checkK) == true, "recK missing from DB");
+			TEST_ASSERT(checkK.value == "Val K Updated", "recK value in DB did not update");
+		}
+
+		// Verify 2: Target cache entry was invalidated due to UpdateCache failure
+		TEST_ASSERT(mockCache.Contains("rec-111") == false, "Stale cache entry rec-111 was not invalidated after UpdateCache failure!");
+
+		// Verify 3: Unrelated cache entry remains intact
+		TEST_ASSERT(mockCache.Contains("rec-112") == true, "Unrelated cache entry rec-112 was unexpectedly removed!");
+
+		// Verify 4: Subsequent GetRecord re-populates cache with fresh DB value
+		mockCache.SetThrowOnUpdateCache(false);
+		OpenWifi::TestRecord reFetchedRec;
+		TEST_ASSERT(db.GetRecord("id", "rec-111", reFetchedRec) == true, "GetRecord failed after cache invalidation");
+		TEST_ASSERT(reFetchedRec.value == "Val K Updated", "GetRecord returned incorrect value after re-populating cache");
+		TEST_ASSERT(mockCache.Contains("rec-111") == true, "Cache was not re-populated after GetRecord miss");
+
+		OpenWifi::TestRecord refreshedCachedRec;
+		TEST_ASSERT(mockCache.GetFromCache("id", "rec-111", refreshedCachedRec) == true, "rec-111 missing from cache after re-population");
+		TEST_ASSERT(refreshedCachedRec.value == "Val K Updated", "Cache was re-populated with stale value");
+
+		std::cout << "PASSED" << std::endl;
+	}
+
 	std::cout << "[Framework Unit Test] All DbTransaction & Transaction-Aware ORM Tests Passed Successfully!" << std::endl;
 	return 0;
 }
+

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ */
+
+#include <iostream>
+#include <cstdlib>
+
+#include "Poco/Data/SessionPool.h"
+#include "Poco/Data/SQLite/Connector.h"
+#include "Poco/Logger.h"
+#include "framework/DbTransaction.h"
+#include "framework/StorageClass.h"
+#include "framework/orm.h"
+
+#define TEST_ASSERT(cond, msg) \
+	do { \
+		if (!(cond)) { \
+			std::cerr << "TEST FAILURE [" << __FILE__ << ":" << __LINE__ << "]: " << msg << std::endl; \
+			std::exit(1); \
+		} \
+	} while (0)
+
+namespace OpenWifi {
+
+	// Minimal record struct for testing session-aware ORM operations
+	struct TestRecord {
+		std::string id;
+		std::string name;
+		std::string value;
+
+		void to_json(Poco::JSON::Object &) const {}
+		bool from_json(const Poco::JSON::Object::Ptr &) { return true; }
+	};
+
+	typedef Poco::Tuple<std::string, std::string, std::string> TestRecordTuple;
+
+} // namespace OpenWifi
+
+template <>
+void ORM::DB<OpenWifi::TestRecordTuple, OpenWifi::TestRecord>::Convert(
+	const OpenWifi::TestRecordTuple &In, OpenWifi::TestRecord &Out) {
+	Out.id = In.get<0>();
+	Out.name = In.get<1>();
+	Out.value = In.get<2>();
+}
+
+template <>
+void ORM::DB<OpenWifi::TestRecordTuple, OpenWifi::TestRecord>::Convert(
+	const OpenWifi::TestRecord &In, OpenWifi::TestRecordTuple &Out) {
+	Out.set<0>(In.id);
+	Out.set<1>(In.name);
+	Out.set<2>(In.value);
+}
+
+class TestDB : public ORM::DB<OpenWifi::TestRecordTuple, OpenWifi::TestRecord> {
+  public:
+	TestDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
+		: DB(T, "test_records",
+			 ORM::FieldVec{
+				 ORM::Field{"id", ORM::FieldType::FT_TEXT, 0, true},
+				 ORM::Field{"name", ORM::FieldType::FT_TEXT},
+				 ORM::Field{"value", ORM::FieldType::FT_TEXT}
+			 },
+			 ORM::IndexVec{}, P, L, "tst") {}
+};
+
+int main() {
+	std::cout << "[Framework Unit Test] Initializing DbTransaction & Session-Aware ORM Tests..." << std::endl;
+
+	Poco::Data::SQLite::Connector::registerConnector();
+	Poco::Data::SessionPool pool("SQLite", "db_transaction_unittest.db");
+	Poco::Logger &logger = Poco::Logger::get("DbTransactionTest");
+
+	TestDB db(OpenWifi::DBType::sqlite, pool, logger);
+	TEST_ASSERT(db.Create(), "Failed to create transaction test table");
+
+	// Clear leftover test records using valid non-empty clause
+	TEST_ASSERT(db.DeleteRecords("1=1"), "Failed to clear transaction test table");
+
+	// -------------------------------------------------------------------------
+	// Test 1: Commit Persists Multi-Operation Session-Aware Operations (All 6 Overloads)
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 1: Commit Persists Multi-Operation Session-Aware Operations... " << std::flush;
+		OpenWifi::DbTransaction tx(pool.get(), logger);
+
+		OpenWifi::TestRecord recA{"rec-101", "Record A", "Val A Initial"};
+		OpenWifi::TestRecord recB{"rec-102", "Record B", "Val B"};
+		OpenWifi::TestRecord recC{"rec-103", "Record C", "Val C"};
+
+		// 1. CreateRecord(session, ...)
+		TEST_ASSERT(db.CreateRecord(tx.Session(), recA) == true, "Failed to create recA in transaction");
+		TEST_ASSERT(db.CreateRecord(tx.Session(), recB) == true, "Failed to create recB in transaction");
+		TEST_ASSERT(db.CreateRecord(tx.Session(), recC) == true, "Failed to create recC in transaction");
+
+		// 2. GetRecords(session, ...) inside transaction
+		TestDB::RecordVec insideTxRecords;
+		TEST_ASSERT(db.GetRecords(tx.Session(), 0, 10, insideTxRecords) == true, "GetRecords failed inside transaction");
+		TEST_ASSERT(insideTxRecords.size() == 3, "Expected 3 records inside transaction session");
+
+		// 3. GetRecord(session, ...) inside transaction
+		OpenWifi::TestRecord insideTxRecA;
+		TEST_ASSERT(db.GetRecord(tx.Session(), "id", "rec-101", insideTxRecA) == true, "GetRecord failed inside transaction");
+		TEST_ASSERT(insideTxRecA.value == "Val A Initial", "recA value mismatch inside transaction");
+
+		// 4. UpdateRecord(session, ...) inside transaction
+		insideTxRecA.value = "Val A Updated";
+		TEST_ASSERT(db.UpdateRecord(tx.Session(), "id", "rec-101", insideTxRecA) == true, "UpdateRecord failed inside transaction");
+
+		// 5. DeleteRecord(session, ...) inside transaction
+		TEST_ASSERT(db.DeleteRecord(tx.Session(), "id", "rec-102") == true, "DeleteRecord failed inside transaction");
+
+		// 6. DeleteRecords(session, ...) inside transaction
+		TEST_ASSERT(db.DeleteRecords(tx.Session(), "id='rec-103'") == true, "DeleteRecords failed inside transaction");
+
+		TEST_ASSERT(tx.Commit() == true, "Failed to commit transaction");
+
+		// Verify outside transaction: recA exists with updated value, recB & recC were deleted
+		OpenWifi::TestRecord checkA, checkB, checkC;
+		TEST_ASSERT(db.GetRecord("id", "rec-101", checkA) == true, "recA missing after commit");
+		TEST_ASSERT(checkA.value == "Val A Updated", "recA updated value did not persist");
+		TEST_ASSERT(db.GetRecord("id", "rec-102", checkB) == false, "recB unexpectedly exists after DeleteRecord commit");
+		TEST_ASSERT(db.GetRecord("id", "rec-103", checkC) == false, "recC unexpectedly exists after DeleteRecords commit");
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 2: Multi-Operation Explicit Rollback Discards Uncommitted Writes
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 2: Multi-Operation Explicit Rollback... " << std::flush;
+		OpenWifi::DbTransaction tx(pool.get(), logger);
+
+		OpenWifi::TestRecord recD{"rec-104", "Record D", "Val D"};
+		OpenWifi::TestRecord recE{"rec-105", "Record E", "Val E"};
+
+		TEST_ASSERT(db.CreateRecord(tx.Session(), recD) == true, "Failed to create recD in transaction");
+		TEST_ASSERT(db.CreateRecord(tx.Session(), recE) == true, "Failed to create recE in transaction");
+
+		TEST_ASSERT(tx.Rollback() == true, "Failed to rollback transaction");
+
+		// Verify neither record exists outside transaction
+		OpenWifi::TestRecord checkD, checkE;
+		TEST_ASSERT(db.GetRecord("id", "rec-104", checkD) == false, "recD exists after explicit rollback");
+		TEST_ASSERT(db.GetRecord("id", "rec-105", checkE) == false, "recE exists after explicit rollback");
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 3: RAII Scope Exit Auto-Rollback (Destructor)
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 3: RAII Scope Exit Auto-Rollback... " << std::flush;
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recF{"rec-106", "Record F", "Val F"};
+			TEST_ASSERT(db.CreateRecord(tx.Session(), recF) == true, "Failed to create recF in transaction");
+			// Intentionally exit scope without Commit() or Rollback()
+		}
+
+		// Verify record F was rolled back on destructor scope exit
+		OpenWifi::TestRecord checkF;
+		TEST_ASSERT(db.GetRecord("id", "rec-106", checkF) == false, "recF exists after scope exit auto-rollback");
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 4: Multi-Operation Failure Atomicity
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 4: Multi-Operation Failure Atomicity... " << std::flush;
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recG{"rec-107", "Record G", "Val G"};
+			TEST_ASSERT(db.CreateRecord(tx.Session(), recG) == true, "Failed to create recG in transaction");
+
+			// Attempt duplicate primary key insertion on same tx session
+			OpenWifi::TestRecord recG_dup{"rec-107", "Record G Dup", "Val G Dup"};
+			bool secondWriteResult = db.CreateRecord(tx.Session(), recG_dup);
+			TEST_ASSERT(secondWriteResult == false, "Duplicate primary key write unexpectedly succeeded");
+
+			// Exit scope without commit due to failed second operation
+		}
+
+		// Verify recG was completely rolled back due to second write failure
+		OpenWifi::TestRecord checkG;
+		TEST_ASSERT(db.GetRecord("id", "rec-107", checkG) == false, "recG exists after second write failure atomicity rollback");
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 5: Inactive Transaction Safety
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 5: Inactive Transaction Safety... " << std::flush;
+		OpenWifi::DbTransaction tx(pool.get(), logger);
+		TEST_ASSERT(tx.Commit() == true, "Failed initial commit");
+
+		// Subsequent operations on committed/inactive transaction must fail gracefully
+		TEST_ASSERT(tx.Commit() == false, "Second commit unexpectedly succeeded on inactive transaction");
+		TEST_ASSERT(tx.Rollback() == false, "Rollback unexpectedly succeeded on inactive transaction");
+
+		bool threwException = false;
+		try {
+			tx.Session();
+		} catch (const Poco::IllegalStateException &) {
+			threwException = true;
+		}
+		TEST_ASSERT(threwException == true, "Session() failed to throw IllegalStateException on inactive transaction");
+		std::cout << "PASSED" << std::endl;
+	}
+
+	std::cout << "[Framework Unit Test] All DbTransaction & Session-Aware ORM Tests Passed Successfully!" << std::endl;
+	return 0;
+}

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -64,12 +64,19 @@ namespace OpenWifi {
 			throwOnDelete_ = shouldThrow;
 		}
 
+		void SetThrowOnInvalidateAll(bool shouldThrow) {
+			throwOnInvalidateAll_ = shouldThrow;
+		}
+
 		bool InvalidateAllCalled() const {
 			return invalidateAllCalled_;
 		}
 
 		void InvalidateAll() override {
 			invalidateAllCalled_ = true;
+			if (throwOnInvalidateAll_) {
+				throw Poco::Exception("Mock InvalidateAll simulated failure");
+			}
 			cache_map_.clear();
 		}
 
@@ -97,6 +104,7 @@ namespace OpenWifi {
 			cache_map_.clear();
 			throwOnUpdateCache_ = false;
 			throwOnDelete_ = false;
+			throwOnInvalidateAll_ = false;
 			invalidateAllCalled_ = false;
 		}
 
@@ -104,6 +112,7 @@ namespace OpenWifi {
 		std::map<std::string, TestRecord> cache_map_;
 		bool throwOnUpdateCache_ = false;
 		bool throwOnDelete_ = false;
+		bool throwOnInvalidateAll_ = false;
 		bool invalidateAllCalled_ = false;
 	};
 
@@ -485,6 +494,79 @@ int main() {
 		OpenWifi::TestRecord reFetchedRecM;
 		TEST_ASSERT(db.GetRecord("id", "rec-113", reFetchedRecM) == false, "GetRecord returned stale data for deleted row");
 
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 9: Transactional Delete Missing Row Failure Causes Caller Rollback
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 9: Transactional Delete Missing Row Failure... " << std::flush;
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+
+			OpenWifi::TestRecord recO{"rec-115", "Record O", "Val O"};
+			TEST_ASSERT(db.CreateRecord(tx, recO) == true, "CreateRecord failed in Test 9");
+
+			// Attempt deleting a non-existent row inside the transaction
+			TEST_ASSERT(db.DeleteRecord(tx, "id", "does-not-exist") == false, "DeleteRecord unexpectedly succeeded for missing row");
+
+			// Caller rolls back due to failure of required delete step
+			TEST_ASSERT(tx.Rollback() == true, "Rollback failed after DeleteRecord failure");
+		}
+
+		// Verify earlier write (recO) was rolled back from DB as well
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkO;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-115", checkO) == false, "Earlier write remained in DB after rollback");
+		}
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 10: Post-Commit Double Cache Failure (Delete & InvalidateAll Throw)
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 10: Post-Commit Double Cache Failure (Delete & InvalidateAll Throw)... " << std::flush;
+		mockCache.Clear();
+
+		// Pre-populate DB & Cache with 1 record
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recP{"rec-116", "Record P", "Val P"};
+			TEST_ASSERT(db.CreateRecord(tx, recP) == true, "Failed to create recP");
+			TEST_ASSERT(tx.Commit() == true, "Failed to commit initial record for Test 10");
+		}
+
+		TEST_ASSERT(mockCache.Contains("rec-116") == true, "recP missing from cache");
+
+		// Perform transactional DeleteRecord with both Delete and InvalidateAll set to throw
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			TEST_ASSERT(db.DeleteRecord(tx, "id", "rec-116") == true, "DeleteRecord failed inside tx");
+
+			mockCache.SetThrowOnDelete(true);
+			mockCache.SetThrowOnInvalidateAll(true);
+
+			// DB commit MUST still return true even when both post-commit cache operations throw
+			TEST_ASSERT(tx.Commit() == true, "DB commit must remain successful when cache recovery fails");
+		}
+
+		// Verify 1: DB deletion remains committed
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkP;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-116", checkP) == false, "recP unexpectedly exists in DB after deletion");
+		}
+
+		// Verify 2: InvalidateAll() was attempted
+		TEST_ASSERT(mockCache.InvalidateAllCalled() == true, "InvalidateAll() was not attempted after Delete failure!");
+
+		// Verify 3: Stale cache entry remains in cache when both Delete and InvalidateAll throw (best-effort behavior)
+		TEST_ASSERT(mockCache.Contains("rec-116") == true, "Expected stale cache entry to remain when both Delete and InvalidateAll throw");
+
+		mockCache.Clear();
 		std::cout << "PASSED" << std::endl;
 	}
 

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -60,6 +60,19 @@ namespace OpenWifi {
 			throwOnUpdateCache_ = shouldThrow;
 		}
 
+		void SetThrowOnDelete(bool shouldThrow) {
+			throwOnDelete_ = shouldThrow;
+		}
+
+		bool InvalidateAllCalled() const {
+			return invalidateAllCalled_;
+		}
+
+		void InvalidateAll() override {
+			invalidateAllCalled_ = true;
+			cache_map_.clear();
+		}
+
 		void UpdateCache(const TestRecord &R) override {
 			if (throwOnUpdateCache_) {
 				throw Poco::Exception("Mock UpdateCache simulated failure");
@@ -68,6 +81,9 @@ namespace OpenWifi {
 		}
 
 		void Delete(const std::string &FieldName, const std::string &Value) override {
+			if (throwOnDelete_) {
+				throw Poco::Exception("Mock Delete simulated failure");
+			}
 			if (FieldName == "id") {
 				cache_map_.erase(Value);
 			}
@@ -79,11 +95,16 @@ namespace OpenWifi {
 
 		void Clear() {
 			cache_map_.clear();
+			throwOnUpdateCache_ = false;
+			throwOnDelete_ = false;
+			invalidateAllCalled_ = false;
 		}
 
 	  private:
 		std::map<std::string, TestRecord> cache_map_;
 		bool throwOnUpdateCache_ = false;
+		bool throwOnDelete_ = false;
+		bool invalidateAllCalled_ = false;
 	};
 
 } // namespace OpenWifi
@@ -397,6 +418,7 @@ int main() {
 
 		// Verify 3: Unrelated cache entry remains intact
 		TEST_ASSERT(mockCache.Contains("rec-112") == true, "Unrelated cache entry rec-112 was unexpectedly removed!");
+		TEST_ASSERT(mockCache.InvalidateAllCalled() == false, "InvalidateAll() was unexpectedly called when targeted invalidation succeeded");
 
 		// Verify 4: Subsequent GetRecord re-populates cache with fresh DB value
 		mockCache.SetThrowOnUpdateCache(false);
@@ -408,6 +430,60 @@ int main() {
 		OpenWifi::TestRecord refreshedCachedRec;
 		TEST_ASSERT(mockCache.GetFromCache("id", "rec-111", refreshedCachedRec) == true, "rec-111 missing from cache after re-population");
 		TEST_ASSERT(refreshedCachedRec.value == "Val K Updated", "Cache was re-populated with stale value");
+
+		std::cout << "PASSED" << std::endl;
+	}
+
+	// -------------------------------------------------------------------------
+	// Test 8: Transactional Delete Post-Commit Delete Failure Fallback to InvalidateAll()
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 8: Transactional Delete Post-Commit Delete Failure Fallback to InvalidateAll()... " << std::flush;
+		mockCache.Clear();
+
+		// Pre-populate DB & Cache with 2 records
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recM{"rec-113", "Record M", "Val M"};
+			OpenWifi::TestRecord recN{"rec-114", "Record N", "Val N"};
+			TEST_ASSERT(db.CreateRecord(tx, recM) == true, "Failed to create recM");
+			TEST_ASSERT(db.CreateRecord(tx, recN) == true, "Failed to create recN");
+			TEST_ASSERT(tx.Commit() == true, "Failed to commit initial records for Test 8");
+		}
+
+		TEST_ASSERT(mockCache.Contains("rec-113") == true, "recM missing from cache");
+		TEST_ASSERT(mockCache.Contains("rec-114") == true, "recN missing from cache");
+
+		// Perform transactional DeleteRecord with mockCache set to throw on Delete
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			TEST_ASSERT(db.DeleteRecord(tx, "id", "rec-113") == true, "DeleteRecord failed inside tx");
+
+			mockCache.SetThrowOnDelete(true);
+			TEST_ASSERT(tx.Commit() == true, "Commit() must succeed even if post-commit Delete throws");
+		}
+
+		// Verify 1: DB deletion remains committed and unrelated DB records persist
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkM, checkN;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-113", checkM) == false, "recM unexpectedly exists in DB after deletion");
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-114", checkN) == true, "recN unexpectedly missing from DB after cache invalidation fallback");
+		}
+
+		// Verify 2: InvalidateAll() was called as last-resort fallback
+		TEST_ASSERT(mockCache.InvalidateAllCalled() == true, "InvalidateAll() was not called after Delete failure!");
+
+		// Verify 3: Stale target cache entry rec-113 is gone
+		TEST_ASSERT(mockCache.Contains("rec-113") == false, "Stale deleted entry rec-113 was served from cache!");
+
+		// Verify 4: Unrelated cache entry rec-114 is also cleared because full invalidation occurred
+		TEST_ASSERT(mockCache.Contains("rec-114") == false, "Unrelated entry rec-114 was not cleared during InvalidateAll()!");
+
+		// Verify 5: Subsequent GetRecord for deleted recM returns false (does not return stale cache data)
+		mockCache.SetThrowOnDelete(false);
+		OpenWifi::TestRecord reFetchedRecM;
+		TEST_ASSERT(db.GetRecord("id", "rec-113", reFetchedRecM) == false, "GetRecord returned stale data for deleted row");
 
 		std::cout << "PASSED" << std::endl;
 	}

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <map>
 
 #include "Poco/Data/SessionPool.h"
 #include "Poco/Data/SQLite/Connector.h"
@@ -35,6 +36,48 @@ namespace OpenWifi {
 
 	typedef Poco::Tuple<std::string, std::string, std::string> TestRecordTuple;
 
+	// Mock DBCache for testing post-commit cache synchronization
+	class MockTestDBCache : public ORM::DBCache<TestRecord> {
+	  public:
+		MockTestDBCache() : DBCache<TestRecord>(100, 600) {}
+
+		void Create(const TestRecord &R) override {
+			cache_map_[R.id] = R;
+		}
+
+		bool GetFromCache(const std::string &FieldName, const std::string &Value, TestRecord &R) override {
+			if (FieldName == "id") {
+				auto it = cache_map_.find(Value);
+				if (it != cache_map_.end()) {
+					R = it->second;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		void UpdateCache(const TestRecord &R) override {
+			cache_map_[R.id] = R;
+		}
+
+		void Delete(const std::string &FieldName, const std::string &Value) override {
+			if (FieldName == "id") {
+				cache_map_.erase(Value);
+			}
+		}
+
+		bool Contains(const std::string &id) const {
+			return cache_map_.find(id) != cache_map_.end();
+		}
+
+		void Clear() {
+			cache_map_.clear();
+		}
+
+	  private:
+		std::map<std::string, TestRecord> cache_map_;
+	};
+
 } // namespace OpenWifi
 
 template <>
@@ -55,73 +98,75 @@ void ORM::DB<OpenWifi::TestRecordTuple, OpenWifi::TestRecord>::Convert(
 
 class TestDB : public ORM::DB<OpenWifi::TestRecordTuple, OpenWifi::TestRecord> {
   public:
-	TestDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L)
+	TestDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L, ORM::DBCache<OpenWifi::TestRecord> *Cache = nullptr)
 		: DB(T, "test_records",
 			 ORM::FieldVec{
 				 ORM::Field{"id", ORM::FieldType::FT_TEXT, 0, true},
 				 ORM::Field{"name", ORM::FieldType::FT_TEXT},
 				 ORM::Field{"value", ORM::FieldType::FT_TEXT}
 			 },
-			 ORM::IndexVec{}, P, L, "tst") {}
+			 ORM::IndexVec{}, P, L, "tst", Cache) {}
 };
 
 int main() {
-	std::cout << "[Framework Unit Test] Initializing DbTransaction & Session-Aware ORM Tests..." << std::endl;
+	std::cout << "[Framework Unit Test] Initializing DbTransaction & Transaction-Aware ORM Tests..." << std::endl;
 
 	Poco::Data::SQLite::Connector::registerConnector();
 	Poco::Data::SessionPool pool("SQLite", "db_transaction_unittest.db");
 	Poco::Logger &logger = Poco::Logger::get("DbTransactionTest");
 
-	TestDB db(OpenWifi::DBType::sqlite, pool, logger);
+	OpenWifi::MockTestDBCache mockCache;
+	TestDB db(OpenWifi::DBType::sqlite, pool, logger, &mockCache);
 	TEST_ASSERT(db.Create(), "Failed to create transaction test table");
 
-	// Clear leftover test records using valid non-empty clause
-	TEST_ASSERT(db.DeleteRecords("1=1"), "Failed to clear transaction test table");
+	// Clear leftover test records using low-level DeleteRecords on session
+	{
+		Poco::Data::Session clearSession = pool.get();
+		TEST_ASSERT(db.DeleteRecords(clearSession, "1=1"), "Failed to clear transaction test table");
+		mockCache.Clear();
+	}
 
 	// -------------------------------------------------------------------------
-	// Test 1: Commit Persists Multi-Operation Session-Aware Operations (All 6 Overloads)
+	// Test 1: Commit Persists Multi-Operation Transactional Operations
 	// -------------------------------------------------------------------------
 	{
-		std::cout << "  - Test 1: Commit Persists Multi-Operation Session-Aware Operations... " << std::flush;
+		std::cout << "  - Test 1: Commit Persists Multi-Operation Transactional Operations... " << std::flush;
 		OpenWifi::DbTransaction tx(pool.get(), logger);
 
 		OpenWifi::TestRecord recA{"rec-101", "Record A", "Val A Initial"};
 		OpenWifi::TestRecord recB{"rec-102", "Record B", "Val B"};
-		OpenWifi::TestRecord recC{"rec-103", "Record C", "Val C"};
 
-		// 1. CreateRecord(session, ...)
-		TEST_ASSERT(db.CreateRecord(tx.Session(), recA) == true, "Failed to create recA in transaction");
-		TEST_ASSERT(db.CreateRecord(tx.Session(), recB) == true, "Failed to create recB in transaction");
-		TEST_ASSERT(db.CreateRecord(tx.Session(), recC) == true, "Failed to create recC in transaction");
+		// 1. CreateRecord(tx, ...)
+		TEST_ASSERT(db.CreateRecord(tx, recA) == true, "Failed to create recA in transaction");
+		TEST_ASSERT(db.CreateRecord(tx, recB) == true, "Failed to create recB in transaction");
 
 		// 2. GetRecords(session, ...) inside transaction
 		TestDB::RecordVec insideTxRecords;
 		TEST_ASSERT(db.GetRecords(tx.Session(), 0, 10, insideTxRecords) == true, "GetRecords failed inside transaction");
-		TEST_ASSERT(insideTxRecords.size() == 3, "Expected 3 records inside transaction session");
+		TEST_ASSERT(insideTxRecords.size() == 2, "Expected 2 records inside transaction session");
 
 		// 3. GetRecord(session, ...) inside transaction
 		OpenWifi::TestRecord insideTxRecA;
 		TEST_ASSERT(db.GetRecord(tx.Session(), "id", "rec-101", insideTxRecA) == true, "GetRecord failed inside transaction");
 		TEST_ASSERT(insideTxRecA.value == "Val A Initial", "recA value mismatch inside transaction");
 
-		// 4. UpdateRecord(session, ...) inside transaction
+		// 4. UpdateRecord(tx, ...) inside transaction
 		insideTxRecA.value = "Val A Updated";
-		TEST_ASSERT(db.UpdateRecord(tx.Session(), "id", "rec-101", insideTxRecA) == true, "UpdateRecord failed inside transaction");
+		TEST_ASSERT(db.UpdateRecord(tx, "id", "rec-101", insideTxRecA) == true, "UpdateRecord failed inside transaction");
 
-		// 5. DeleteRecord(session, ...) inside transaction
-		TEST_ASSERT(db.DeleteRecord(tx.Session(), "id", "rec-102") == true, "DeleteRecord failed inside transaction");
-
-		// 6. DeleteRecords(session, ...) inside transaction
-		TEST_ASSERT(db.DeleteRecords(tx.Session(), "id='rec-103'") == true, "DeleteRecords failed inside transaction");
+		// 5. DeleteRecord(tx, ...) inside transaction for recB
+		TEST_ASSERT(db.DeleteRecord(tx, "id", "rec-102") == true, "DeleteRecord failed inside transaction for recB");
 
 		TEST_ASSERT(tx.Commit() == true, "Failed to commit transaction");
 
-		// Verify outside transaction: recA exists with updated value, recB & recC were deleted
-		OpenWifi::TestRecord checkA, checkB, checkC;
-		TEST_ASSERT(db.GetRecord("id", "rec-101", checkA) == true, "recA missing after commit");
-		TEST_ASSERT(checkA.value == "Val A Updated", "recA updated value did not persist");
-		TEST_ASSERT(db.GetRecord("id", "rec-102", checkB) == false, "recB unexpectedly exists after DeleteRecord commit");
-		TEST_ASSERT(db.GetRecord("id", "rec-103", checkC) == false, "recC unexpectedly exists after DeleteRecords commit");
+		// Verify directly against database via session (bypassing Cache_)
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkA, checkB;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-101", checkA) == true, "recA missing from database after commit");
+			TEST_ASSERT(checkA.value == "Val A Updated", "recA updated value did not persist to database");
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-102", checkB) == false, "recB unexpectedly exists in database after DeleteRecord commit");
+		}
 		std::cout << "PASSED" << std::endl;
 	}
 
@@ -135,15 +180,18 @@ int main() {
 		OpenWifi::TestRecord recD{"rec-104", "Record D", "Val D"};
 		OpenWifi::TestRecord recE{"rec-105", "Record E", "Val E"};
 
-		TEST_ASSERT(db.CreateRecord(tx.Session(), recD) == true, "Failed to create recD in transaction");
-		TEST_ASSERT(db.CreateRecord(tx.Session(), recE) == true, "Failed to create recE in transaction");
+		TEST_ASSERT(db.CreateRecord(tx, recD) == true, "Failed to create recD in transaction");
+		TEST_ASSERT(db.CreateRecord(tx, recE) == true, "Failed to create recE in transaction");
 
 		TEST_ASSERT(tx.Rollback() == true, "Failed to rollback transaction");
 
-		// Verify neither record exists outside transaction
-		OpenWifi::TestRecord checkD, checkE;
-		TEST_ASSERT(db.GetRecord("id", "rec-104", checkD) == false, "recD exists after explicit rollback");
-		TEST_ASSERT(db.GetRecord("id", "rec-105", checkE) == false, "recE exists after explicit rollback");
+		// Verify neither record exists in database after explicit rollback
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkD, checkE;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-104", checkD) == false, "recD exists in database after explicit rollback");
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-105", checkE) == false, "recE exists in database after explicit rollback");
+		}
 		std::cout << "PASSED" << std::endl;
 	}
 
@@ -155,13 +203,16 @@ int main() {
 		{
 			OpenWifi::DbTransaction tx(pool.get(), logger);
 			OpenWifi::TestRecord recF{"rec-106", "Record F", "Val F"};
-			TEST_ASSERT(db.CreateRecord(tx.Session(), recF) == true, "Failed to create recF in transaction");
+			TEST_ASSERT(db.CreateRecord(tx, recF) == true, "Failed to create recF in transaction");
 			// Intentionally exit scope without Commit() or Rollback()
 		}
 
-		// Verify record F was rolled back on destructor scope exit
-		OpenWifi::TestRecord checkF;
-		TEST_ASSERT(db.GetRecord("id", "rec-106", checkF) == false, "recF exists after scope exit auto-rollback");
+		// Verify record F was rolled back from database on destructor scope exit
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkF;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-106", checkF) == false, "recF exists in database after scope exit auto-rollback");
+		}
 		std::cout << "PASSED" << std::endl;
 	}
 
@@ -173,19 +224,22 @@ int main() {
 		{
 			OpenWifi::DbTransaction tx(pool.get(), logger);
 			OpenWifi::TestRecord recG{"rec-107", "Record G", "Val G"};
-			TEST_ASSERT(db.CreateRecord(tx.Session(), recG) == true, "Failed to create recG in transaction");
+			TEST_ASSERT(db.CreateRecord(tx, recG) == true, "Failed to create recG in transaction");
 
 			// Attempt duplicate primary key insertion on same tx session
 			OpenWifi::TestRecord recG_dup{"rec-107", "Record G Dup", "Val G Dup"};
-			bool secondWriteResult = db.CreateRecord(tx.Session(), recG_dup);
+			bool secondWriteResult = db.CreateRecord(tx, recG_dup);
 			TEST_ASSERT(secondWriteResult == false, "Duplicate primary key write unexpectedly succeeded");
 
 			// Exit scope without commit due to failed second operation
 		}
 
-		// Verify recG was completely rolled back due to second write failure
-		OpenWifi::TestRecord checkG;
-		TEST_ASSERT(db.GetRecord("id", "rec-107", checkG) == false, "recG exists after second write failure atomicity rollback");
+		// Verify recG was completely rolled back from database due to second write failure
+		{
+			Poco::Data::Session verifySession = pool.get();
+			OpenWifi::TestRecord checkG;
+			TEST_ASSERT(db.GetRecord(verifySession, "id", "rec-107", checkG) == false, "recG exists in database after second write failure atomicity rollback");
+		}
 		std::cout << "PASSED" << std::endl;
 	}
 
@@ -211,6 +265,86 @@ int main() {
 		std::cout << "PASSED" << std::endl;
 	}
 
-	std::cout << "[Framework Unit Test] All DbTransaction & Session-Aware ORM Tests Passed Successfully!" << std::endl;
+	// -------------------------------------------------------------------------
+	// Test 6: Mock DBCache Post-Commit Synchronization Guarantees
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 6: Mock DBCache Post-Commit Synchronization Guarantees... " << std::flush;
+		mockCache.Clear();
+
+		// 6a: Transactional CreateRecord updates DBCache ONLY AFTER COMMIT
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recH{"rec-108", "Record H", "Val H"};
+
+			TEST_ASSERT(db.CreateRecord(tx, recH) == true, "Failed to create recH");
+			// Cache MUST NOT be updated during open transaction before commit
+			TEST_ASSERT(mockCache.Contains("rec-108") == false, "MockDBCache unexpectedly updated BEFORE commit!");
+
+			TEST_ASSERT(tx.Commit() == true, "Commit failed in 6a");
+			// Cache MUST be updated AFTER successful commit
+			TEST_ASSERT(mockCache.Contains("rec-108") == true, "MockDBCache failed to update AFTER commit!");
+		}
+
+		// 6b: Transactional UpdateRecord updates DBCache ONLY AFTER COMMIT
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recH_updated{"rec-108", "Record H", "Val H Updated Cache"};
+
+			TEST_ASSERT(db.UpdateRecord(tx, "id", "rec-108", recH_updated) == true, "Failed to update recH");
+			// Cache must hold initial value during transaction before commit
+			OpenWifi::TestRecord cachedPre;
+			TEST_ASSERT(mockCache.GetFromCache("id", "rec-108", cachedPre) == true, "recH missing from cache");
+			TEST_ASSERT(cachedPre.value == "Val H", "Cache mutated prematurely during transaction!");
+
+			TEST_ASSERT(tx.Commit() == true, "Commit failed in 6b");
+			// Cache updated post-commit
+			OpenWifi::TestRecord cachedPost;
+			TEST_ASSERT(mockCache.GetFromCache("id", "rec-108", cachedPost) == true, "recH missing from cache post-commit");
+			TEST_ASSERT(cachedPost.value == "Val H Updated Cache", "Cache failed to update post-commit!");
+		}
+
+		// 6c: Transactional DeleteRecord deletes from DBCache ONLY AFTER COMMIT
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+
+			TEST_ASSERT(db.DeleteRecord(tx, "id", "rec-108") == true, "Failed to delete recH");
+			// Cache entry must still exist during transaction before commit
+			TEST_ASSERT(mockCache.Contains("rec-108") == true, "Cache entry deleted prematurely before commit!");
+
+			TEST_ASSERT(tx.Commit() == true, "Commit failed in 6c");
+			// Cache entry deleted post-commit
+			TEST_ASSERT(mockCache.Contains("rec-108") == false, "Cache entry failed to delete post-commit!");
+		}
+
+		// 6d: Explicit Rollback() does NOT mutate DBCache
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+			OpenWifi::TestRecord recI{"rec-109", "Record I", "Val I"};
+
+			TEST_ASSERT(db.CreateRecord(tx, recI) == true, "Failed to create recI in transaction");
+			TEST_ASSERT(tx.Rollback() == true, "Rollback failed in 6d");
+
+			// Cache must NOT contain recI
+			TEST_ASSERT(mockCache.Contains("rec-109") == false, "Cache mutated after rolled back transaction!");
+		}
+
+		// 6e: Destructor scope-exit auto-rollback does NOT mutate DBCache
+		{
+			{
+				OpenWifi::DbTransaction tx(pool.get(), logger);
+				OpenWifi::TestRecord recJ{"rec-110", "Record J", "Val J"};
+				TEST_ASSERT(db.CreateRecord(tx, recJ) == true, "Failed to create recJ in transaction");
+				// Intentionally exit scope without Commit() or Rollback()
+			}
+
+			// Cache must NOT contain recJ
+			TEST_ASSERT(mockCache.Contains("rec-110") == false, "Cache mutated after scope-exit auto-rollback!");
+		}
+
+		std::cout << "PASSED" << std::endl;
+	}
+
+	std::cout << "[Framework Unit Test] All DbTransaction & Transaction-Aware ORM Tests Passed Successfully!" << std::endl;
 	return 0;
 }

--- a/tests/framework_tests/DbTransaction_test.cpp
+++ b/tests/framework_tests/DbTransaction_test.cpp
@@ -570,6 +570,30 @@ int main() {
 		std::cout << "PASSED" << std::endl;
 	}
 
+	// -------------------------------------------------------------------------
+	// Test 11: DB Session Released Before AfterCommit Callback Execution
+	// -------------------------------------------------------------------------
+	{
+		std::cout << "  - Test 11: DB Session Released Before AfterCommit Callback... " << std::flush;
+		const auto usedBefore = pool.used();
+		int usedInsideCallback = -1;
+
+		{
+			OpenWifi::DbTransaction tx(pool.get(), logger);
+
+			TEST_ASSERT(pool.used() == usedBefore + 1, "Transaction did not acquire one pooled session");
+
+			tx.AfterCommit([&]() {
+				usedInsideCallback = pool.used();
+			});
+
+			TEST_ASSERT(tx.Commit() == true, "Commit failed in Test 11");
+		}
+
+		TEST_ASSERT(usedInsideCallback == usedBefore, "DB session was still checked out during AfterCommit callback");
+		std::cout << "PASSED" << std::endl;
+	}
+
 	std::cout << "[Framework Unit Test] All DbTransaction & Transaction-Aware ORM Tests Passed Successfully!" << std::endl;
 	return 0;
 }


### PR DESCRIPTION
#68

### Problem Fixed
OWPROV did not provide a reusable database transaction mechanism for API workflows that perform multiple related database operations as a single unit.

Individual ORM operations acquire and manage their own database sessions, which prevents multiple creates, updates, or deletes performed by one API request from being committed or rolled back together.

Before this change:
- **No Shared Transaction Support**: API workflows could not execute multiple ORM operations using one caller-owned database transaction.
- **Independent Database Sessions**: Related ORM operations could acquire separate pooled sessions, preventing transaction-level atomicity across the complete workflow.

This PR adds reusable shared-session database transaction support to OWPROV so API workflows can execute multiple related ORM operations using one caller-owned transaction and commit or roll them back as a single unit.

---

### 1. Add shared database transaction support

- **Transaction Wrapper (`framework/DbTransaction.h`)**:
  - Added a transaction wrapper that uses one pooled database session while the transaction is active.
  - The session is released immediately after a successful commit or rollback.
  - Uses the existing POCO transaction mechanism for commit and rollback handling.
  - Automatically rolls back an active, uncommitted transaction when the transaction leaves scope.
  - Provides explicit commit and rollback operations and access to the transaction-bound database session.
  - Added `AfterCommit()` support for actions that run only after a successful database commit.
  - Post-commit actions run synchronously after the database resources are released.
  - Pending post-commit actions are discarded when the transaction is rolled back or leaves scope without being committed.

- **Storage Service (`StorageService.h`)**:
  - Added `BeginTransaction()` to create a caller-owned transaction using a pooled database session.

### 2. Add transaction-aware ORM operations

- **ORM Layer (`framework/orm.h`)**:
  - Added transaction-aware ORM support for caller-owned database transactions.
  - `GetRecord()` and `GetRecords()` accept the transaction-bound `Poco::Data::Session` so reads execute on the same database session as the transaction.
  - `CreateRecord()`, `UpdateRecord()`, and `DeleteRecord()` accept `DbTransaction&`, execute their SQL using the transaction's session, and register any associated cache mutation through `DbTransaction::AfterCommit()`.
  - Transactional `UpdateRecord()` and `DeleteRecord()` require exactly one affected row.
  - They return `false` when the expected row is not updated or deleted.
  - Cache create/update/delete actions execute only after a successful database commit and are discarded on rollback.
  - If post-commit `UpdateCache()` fails, the affected cache entry is invalidated.
  - If targeted invalidation fails, `DBCache::InvalidateAll()` is attempted.
  - Cache recovery is best-effort. If full invalidation also fails, stale cache entries may remain.
  - Cache failures do not change a successful database commit.
  - Added `DBCache::InvalidateAll()` as the last-resort full-cache recovery step.
  - `DeleteRecords()` remains a low-level session-based bulk operation without automatic cache synchronization for arbitrary `WHERE`-clause deletions.
  - Transaction lifecycle management remains with the caller so multiple ORM operations can participate in the same transaction.
  - Existing non-transactional ORM CRUD APIs remain unchanged.
---
## Test Evidence

- Added `tests/framework_tests/DbTransaction_test.cpp`.
- Added a `db_transaction_test` CTest target.
- The Docker build now runs CTest so the transaction tests are exercised by the existing CI Docker build path.
- Coverage includes:
  - multiple related writes committed as one transaction;
  - explicit rollback;
  - automatic rollback when an uncommitted transaction leaves scope;
  - rollback after a later write fails following an earlier successful write;
  - inactive transaction behavior;
  - post-commit cache create/update/delete behavior;
  - targeted cache invalidation when a post-commit cache update fails;
  - preservation of unrelated cache entries when targeted invalidation succeeds;
  - cache repopulation with the committed database value after a cache miss;
  - full-cache invalidation when targeted delete invalidation fails;
  - verification that the database deletion remains committed after cache recovery;
  - verification that cache changes are not applied before commit or after rollback.
  - transactional `DeleteRecord()` failure when the delete does not affect exactly one row;
  - caller rollback after a required delete fails;
  - full-cache invalidation when targeted cache invalidation fails;
  - double cache failure when `InvalidateAll()` also throws;
  - verification that the database commit remains successful after post-commit cache failures;
  - verification that stale cache data may remain when all cache recovery attempts fail.
  - verification that the pooled database session is released before `AfterCommit()` callbacks run.

---
## Reviewer Guidance

Please review this PR against the intended `owprov` database and REST API architecture.

Primary review focus areas:
- Verify that one pooled database session is used while the transaction is active.
- Verify that the session is released before post-commit callbacks run.
- Verify that transaction-aware ORM operations execute using the transaction-bound session and do not start or commit independent transactions.
- Verify that an uncommitted transaction is rolled back when control leaves the transaction scope.
- Verify that existing non-transactional ORM behavior remains unchanged.
- Verify that `Commit()` and `Rollback()` operate on the caller-owned transaction and report failure without throwing.
- Verify that successful commit and rollback release the transaction resources immediately.
- Verify that `AfterCommit()` callbacks run only after the database resources are released.
- Verify that transactional create/update/delete operations do not mutate `Cache_` before commit.
- Verify that transactional `UpdateRecord()` and `DeleteRecord()` require exactly one affected row.
- Verify that cache create/update/delete actions execute only after a successful commit and are discarded on rollback.
- Verify that a post-commit `UpdateCache()` failure first invalidates only the affected cache entry while preserving the successful database commit and unrelated cache entries.
- Verify that targeted cache invalidation falls back to `DBCache::InvalidateAll()`.
- Verify that cache recovery is best-effort.
- Verify that stale cache data may remain if full invalidation also fails.
- Verify that cache failures do not change a successful database commit.
- Verify the transaction and cache guarantees through the `db_transaction_test` CTest coverage.

### **Out of Scope**
- This PR provides only the reusable database transaction infrastructure. Conversion of individual OWPROV APIs to use this transaction mechanism is intentionally handled in separate PRs.
- Existing ORM behavior unrelated to shared transaction support is intentionally unchanged.